### PR TITLE
feat(private): Evalutae private class fields and methods.

### DIFF
--- a/authentication/authentication.service.js
+++ b/authentication/authentication.service.js
@@ -37,7 +37,7 @@ class AuthenticationService {
             ? this.userService.getUserByPhoneNumber(phoneNumber)
             : this.userService.getUserByDisplayName(displayName, membershipType));
 
-        return this.validateUser(user);
+        return this._validateUser(user); // eslint-disable-line no-underscore-dangle
     }
 
     /**
@@ -46,7 +46,7 @@ class AuthenticationService {
      * @returns {Promise}
      * @private
      */
-    validateUser(user = {}) {
+    _validateUser(user = {}) {
         const { bungie: { access_token: accessToken, refresh_token: refreshToken } = {} } = user;
 
         if (!accessToken) {

--- a/destiny2/destiny2.service.js
+++ b/destiny2/destiny2.service.js
@@ -32,7 +32,7 @@ class Destiny2Service extends DestinyService {
      * @returns {Promise}
      * @private
      */
-    async getManifestFromBungie() {
+    async _getManifestFromBungie() {
         const options = {
             headers: {
                 'x-api-key': apiKey,
@@ -67,7 +67,7 @@ class Destiny2Service extends DestinyService {
             return manifest;
         }
 
-        return this.getManifestFromBungie();
+        return this._getManifestFromBungie(); // eslint-disable-line no-underscore-dangle
     }
 
     /**

--- a/health/health.controller.js
+++ b/health/health.controller.js
@@ -31,7 +31,7 @@ class HealthController {
         this.world2 = options.world2Repository;
     }
 
-    deleteKey(key) {
+    _deleteKey(key) {
         return new Promise((resolve, reject) => {
             this.store.del(key, (err, res) => {
                 if (err) {
@@ -43,19 +43,19 @@ class HealthController {
         });
     }
 
-    async getDestinyManifestVersion() {
+    async _getDestinyManifestVersion() {
         const { version } = await this.destinyService.getManifest();
 
         return version;
     }
 
-    async getDestiny2ManifestVersion() {
+    async _getDestiny2ManifestVersion() {
         const { version } = await this.destiny2Service.getManifest();
 
         return version;
     }
 
-    async getDocumentCount() {
+    async _getDocumentCount() {
         const documents = await this.documents.getDocuments('Users',
             'SELECT VALUE COUNT(1) FROM Users', {
                 enableCrossPartitionQuery: true,
@@ -64,7 +64,7 @@ class HealthController {
         return documents[0];
     }
 
-    setKey(key, value) {
+    _setKey(key, value) {
         return new Promise((resolve, reject) => {
             this.store.set(key, value, (err, res) => {
                 if (err) {
@@ -76,22 +76,22 @@ class HealthController {
         });
     }
 
-    async isStoreHealthy() {
+    async _isStoreHealthy() {
         const key = 'Dredgen Yorn';
         const value = 'Thorn';
 
-        const success = await this.setKey(key, value);
+        const success = await this._setKey(key, value); // eslint-disable-line no-underscore-dangle
 
         if (success) {
-            if (await this.validateKey(key, value)) {
-                return this.deleteKey(key);
+            if (await this._validateKey(key, value)) { // eslint-disable-line no-underscore-dangle
+                return this._deleteKey(key); // eslint-disable-line no-underscore-dangle
             }
         }
 
         return false;
     }
 
-    static async twilio() {
+    static async _twilio() {
         const options = {
             url: 'https://gpkpyklzq55q.statuspage.io/api/v2/status.json',
         };
@@ -100,11 +100,11 @@ class HealthController {
         return responseBody.status.description;
     }
 
-    static unhealthy() {
+    static _unhealthy() {
         failures += 1;
     }
 
-    validateKey(key, value) {
+    _validateKey(key, value) {
         return new Promise((resolve, reject) => {
             this.store.get(key, (err, res) => {
                 if (err) {
@@ -116,35 +116,36 @@ class HealthController {
         });
     }
 
-    async getWorldItem() {
+    async _getWorldItem() {
         const [{ itemDescription } = {}] = await this.world.getItemByName('Doctrine of Passing');
 
         return itemDescription;
     }
 
-    async getWorld2Item() {
+    async _getWorld2Item() {
         const [{ displayProperties: { description = notAvailable } = {} } = {}] = await this.world2.getItemByName('Polaris Lance');
 
         return description;
     }
 
     async getHealth(req, res) {
+        /* eslint-disable no-underscore-dangle, max-len */
         failures = 0;
 
-        const documents = await this.getDocumentCount()
-            .catch(err => HealthController.unhealthy(err)) || -1;
-        const manifestVersion = await this.getDestinyManifestVersion()
-            .catch(err => HealthController.unhealthy(err)) || notAvailable;
-        const manifest2Version = await this.getDestiny2ManifestVersion()
-            .catch(err => HealthController.unhealthy(err)) || notAvailable;
-        const store = await this.isStoreHealthy()
-            .catch(err => HealthController.unhealthy(err)) || false;
-        const twilio = await HealthController.twilio()
-            .catch(err => HealthController.unhealthy(err)) || notAvailable;
-        const world = await this.getWorldItem()
-            .catch(err => HealthController.unhealthy(err)) || notAvailable;
-        const world2 = await this.getWorld2Item()
-            .catch(err => HealthController.unhealthy(err)) || notAvailable;
+        const documents = await this._getDocumentCount()
+            .catch(err => HealthController._unhealthy(err)) || -1;
+        const manifestVersion = await this._getDestinyManifestVersion()
+            .catch(err => HealthController._unhealthy(err)) || notAvailable;
+        const manifest2Version = await this._getDestiny2ManifestVersion()
+            .catch(err => HealthController._unhealthy(err)) || notAvailable;
+        const store = await this._isStoreHealthy()
+            .catch(err => HealthController._unhealthy(err)) || false;
+        const twilio = await HealthController._twilio()
+            .catch(err => HealthController._unhealthy(err)) || notAvailable;
+        const world = await this._getWorldItem()
+            .catch(err => HealthController._unhealthy(err)) || notAvailable;
+        const world2 = await this._getWorld2Item()
+            .catch(err => HealthController._unhealthy(err)) || notAvailable;
 
         res.status(failures ? 503 : 200).json({
             documents,

--- a/twilio/twilio.controller.js
+++ b/twilio/twilio.controller.js
@@ -51,7 +51,7 @@ class TwilioController {
         const promises = itemCategoryHashes.map(itemCategoryHash => this.world
             .getItemCategory(itemCategoryHash));
         const itemCategories = await Promise.all(promises);
-        const filteredCategories = itemCategories.filter(({ hash }) => hash > 1);
+        const filteredCategories = itemCategories.filter(({ hash1 }) => hash1 > 1);
         const sortedCategories = _.sortBy(filteredCategories,
             itemCategory => itemCategory.hash);
         const itemCategory = _.reduce(sortedCategories, (memo, { shortTitle }) => (`${memo + shortTitle} `), ' ')
@@ -105,7 +105,7 @@ class TwilioController {
      */
     async _queryItem(itemName) {
         const allItems = await this.world.getItemByName(itemName.replace(/[\u2018\u2019]/g, '\''));
-        const items = allItems.filter(({ itemName, itemType }) => !itemName.includes('Catalyst')
+        const items = allItems.filter(({ itemType }) => !itemName.includes('Catalyst')
             && [2, 3, 4].includes(itemType));
 
         if (items.length > 0) {
@@ -114,13 +114,13 @@ class TwilioController {
                 const keys = Object.keys(groups);
 
                 if (keys.length === 1) {
-                    return this._getItem(items[0]);
+                    return this._getItem(items[0]); // eslint-disable-line no-underscore-dangle
                 }
 
                 return items;
             }
 
-            return await this._getItem(items[0]);
+            return this._getItem(items[0]); // eslint-disable-line no-underscore-dangle
         }
 
         return [];
@@ -131,13 +131,13 @@ class TwilioController {
      * @param req
      * @param res
      */
-    async fallback(req, res) {
+    static async fallback(req, res) {
         const header = req.headers['x-twilio-signature'];
         const twiml = new MessagingResponse();
 
         // eslint-disable-next-line max-len
         if (twilio.validateRequest(authToken, header, process.env.DOMAIN + req.originalUrl, req.body)) {
-            twiml.message(attributes, TwilioController._getRandomResponseForAnError());
+            twiml.message(attributes, TwilioController._getRandomResponseForAnError()); // eslint-disable-line no-underscore-dangle, max-len
             res.writeHead(200, {
                 'Content-Type': 'text/xml',
             });
@@ -243,7 +243,9 @@ class TwilioController {
                 });
 
                 return res.end(twiml.toString());
-            } else if (message === 'xur') {
+            }
+
+            if (message === 'xur') {
                 try {
                     const {
                         bungie: {
@@ -281,7 +283,7 @@ class TwilioController {
 
                     log.error(err);
 
-                    twiml.message(attributes, TwilioController._getRandomResponseForNoResults());
+                    twiml.message(attributes, TwilioController._getRandomResponseForNoResults()); // eslint-disable-line no-underscore-dangle, max-len
                     res.writeHead(200, {
                         'Content-Type': 'text/xml',
                     });
@@ -297,13 +299,13 @@ class TwilioController {
                 return res.end(twiml.toString());
             } else {
                 const searchTerm = req.body.Body.trim().toLowerCase();
-                const items = await this._queryItem(searchTerm);
+                const items = await this._queryItem(searchTerm); // eslint-disable-line no-underscore-dangle, max-len
 
                 counter += 1;
                 res.cookie('counter', counter);
                 switch (items.length) {
                 case 0: {
-                    twiml.message(attributes, TwilioController._getRandomResponseForNoResults());
+                    twiml.message(attributes, TwilioController._getRandomResponseForNoResults()); // eslint-disable-line no-underscore-dangle, max-len
                     res.writeHead(200, {
                         'Content-Type': 'text/xml',
                     });

--- a/users/user.cache.js
+++ b/users/user.cache.js
@@ -29,7 +29,7 @@ class UserCache {
      * @returns {Promise}
      * @private
      */
-    deleteCache(key) {
+    _deleteCache(key) {
         return new Promise((resolve, reject) => {
             this.client.del(key, (err, res) => {
                 if (err) {
@@ -51,13 +51,13 @@ class UserCache {
         let promise2;
 
         if (phoneNumber) {
-            promise1 = this.deleteCache(this.constructor.getCacheKey(phoneNumber));
+            promise1 = this._deleteCache(this.constructor.getCacheKey(phoneNumber)); // eslint-disable-line no-underscore-dangle, max-len
         } else {
             promise1 = Promise.resolve(); // eslint-disable-line new-cap
         }
 
         if (displayName && membershipType) {
-            promise2 = this.deleteCache(this.constructor.getCacheKey(displayName, membershipType));
+            promise2 = this._deleteCache(this.constructor.getCacheKey(displayName, membershipType)); // eslint-disable-line no-underscore-dangle, max-len
         } else {
             promise2 = Promise.resolve(); // eslint-disable-line new-cap
         }
@@ -76,7 +76,7 @@ class UserCache {
      * @returns {Promise}
      * @private
      */
-    getCache(key) {
+    _getCache(key) {
         return new Promise((resolve, reject) => {
             this.client.get(key, (err, res) => {
                 if (err) {
@@ -96,7 +96,7 @@ class UserCache {
     async getUser(...teeth) {
         const key = this.constructor.getCacheKey(...teeth);
 
-        const user = await this.getCache(key);
+        const user = await this._getCache(key); // eslint-disable-line no-underscore-dangle
         if (user) {
             const { displayName, membershipId, membershipType } = user;
 

--- a/users/user.cache.spec.js
+++ b/users/user.cache.spec.js
@@ -5,7 +5,7 @@ const mockUser = require('../mocks/users.json')[0];
 describe('UserCache', () => {
     let cacheService;
 
-    describe('deleteCache', () => {
+    describe('_deleteCache', () => {
         const cacheKey = 'key';
 
         describe('when client del operation succeeds', () => {
@@ -25,7 +25,7 @@ describe('UserCache', () => {
             });
 
             it('resolves', async () => {
-                const res = await cacheService.deleteCache(cacheKey);
+                const res = await cacheService._deleteCache(cacheKey); // eslint-disable-line no-underscore-dangle, max-len
 
                 expect(res).toEqual(clientResponse);
             });
@@ -47,7 +47,7 @@ describe('UserCache', () => {
                 cacheService = new UserCache();
             });
 
-            it('resolves', () => cacheService.deleteCache(cacheKey)
+            it('resolves', () => cacheService._deleteCache(cacheKey) // eslint-disable-line no-underscore-dangle
                 .then(res => expect(res).toBeUndefined)
                 .catch(err => {
                     expect(err).toEqual(errMessage);
@@ -111,7 +111,7 @@ describe('UserCache', () => {
         });
     });
 
-    describe('getCache', () => {
+    describe('_getCache', () => {
         const cacheKey = 'key';
 
         describe('when client get operation succeeds', () => {
@@ -127,7 +127,7 @@ describe('UserCache', () => {
 
                     cacheService = new UserCache();
 
-                    const res = await cacheService.getCache(cacheKey);
+                    const res = await cacheService._getCache(cacheKey); // eslint-disable-line no-underscore-dangle, max-len
 
                     expect(res).toEqual(mockUser);
                 });
@@ -145,7 +145,7 @@ describe('UserCache', () => {
 
                     cacheService = new UserCache();
 
-                    const res = await cacheService.getCache(cacheKey);
+                    const res = await cacheService._getCache(cacheKey); // eslint-disable-line no-underscore-dangle, max-len
 
                     // eslint-disable-next-line no-unused-expressions, jest/valid-expect
                     expect(res).toBeUndefined;
@@ -167,7 +167,7 @@ describe('UserCache', () => {
 
                 cacheService = new UserCache();
 
-                return cacheService.getCache(cacheKey)
+                return cacheService._getCache(cacheKey) // eslint-disable-line no-underscore-dangle
                     .then(res => expect(res).toBeUndefined)
                     .catch(err => {
                         expect(err).toEqual(errMessage);
@@ -195,13 +195,13 @@ describe('UserCache', () => {
         describe('when cached user is found', () => {
             describe('when membershipId is found', () => {
                 it('returns user', async () => {
-                    jest.spyOn(cacheService, 'getCache')
+                    jest.spyOn(cacheService, '_getCache')
                         .mockResolvedValueOnce(mockUser);
 
                     const user = await cacheService.getUser();
 
                     expect(user).toEqual(mockUser);
-                    expect(cacheService.getCache).toHaveBeenCalledTimes(1);
+                    expect(cacheService._getCache).toHaveBeenCalledTimes(1); // eslint-disable-line no-underscore-dangle, max-len
                 });
             });
 
@@ -209,21 +209,21 @@ describe('UserCache', () => {
                 it('returns user', async () => {
                     const { membershipId, ...mockUser1 } = mockUser;
 
-                    jest.spyOn(cacheService, 'getCache')
+                    jest.spyOn(cacheService, '_getCache')
                         .mockResolvedValueOnce(mockUser1)
                         .mockResolvedValueOnce(mockUser);
 
                     const user = await cacheService.getUser();
 
                     expect(user).toEqual(mockUser);
-                    expect(cacheService.getCache).toHaveBeenCalledTimes(2);
+                    expect(cacheService._getCache).toHaveBeenCalledTimes(2); // eslint-disable-line no-underscore-dangle, max-len
                 });
             });
         });
 
         describe('when cached user is not found', () => {
             it('return undefined', async () => {
-                cacheService.getCache = jest.fn()
+                cacheService._getCache = jest.fn() // eslint-disable-line no-underscore-dangle
                     .mockImplementation(() => Promise.resolve());
 
                 const user = await cacheService.getUser();


### PR DESCRIPTION
I wanted to evaluate the new Node.js v12 features, particularly private class fields and methods.

https://blog.risingstack.com/node-js-12-new-features/

I also looked at some alternatives as described here.

https://exploringjs.com/es6/ch_classes.html#sec_private-data-for-classes

In the end, I wasn't in love with any of these approaches. I'm holding out for when private methods, not just fields, can use the '#' notation.