### PR TITLE
feat(correlation-header): Fix Request Id header.

### DIFF
--- a/destiny/destiny.routes.test.js
+++ b/destiny/destiny.routes.test.js
@@ -33,13 +33,22 @@ describe('/destiny', () => {
         describe('when requesting X number of grimoire cards', () => {
             test('should receive a response with X number of grimoire cards', async () => {
                 const numberOfCards = 2;
+                const requestId = 'Incandescent';
 
-                const getResponse = await axiosAPIClient.get(`/destiny/grimoireCards/${numberOfCards}`);
+                const getResponse = await axiosAPIClient({
+                    method: 'get',
+                    url: `/destiny/grimoireCards/${numberOfCards}`,
+                    headers: {
+                        'X-Request-Id': requestId,
+                    },
+                });
 
                 expect(getResponse).toMatchObject({
                     status: StatusCodes.OK,
                 });
                 expect(getResponse.data.length).toEqual(numberOfCards);
+                expect(getResponse.headers['x-request-id']).toEqual(requestId);
+                expect(getResponse.headers['x-request-id']).toBeDefined();
             });
         });
     });

--- a/helpers/httpLog.js
+++ b/helpers/httpLog.js
@@ -53,7 +53,7 @@ class HttpLog extends PinoHttp {
                 };
             },
             genReqId: (req, res) => {
-                let requestId = req.id ?? req.headers['X-Request-Id'];
+                let requestId = req.headers['x-request-id'];
 
                 if (!requestId) requestId = createId();
                 res.setHeader('X-Request-Id', requestId);


### PR DESCRIPTION
The API has X-Request-Id and a X-Trace-Id headers. X-Request-Id can accepts a consumer defined identifier if provided. The Trace Id is unique to the request made against the Destiny Ghost API.

(Fixed bug with capturing the consumer's defined Request Id. Added tests in the Destiny end-to-end tests to validate the headers.)