### PR TITLE
feat(worker-threads): Load datasets from SQLite database

### DIFF
--- a/destiny2/destiny2.routes.js
+++ b/destiny2/destiny2.routes.js
@@ -108,6 +108,11 @@ const routes = ({
                 });
 
                 const items = await destiny2Controller.getInventory();
+
+                if (!items?.length) {
+                    return res.status(StatusCodes.SERVICE_UNAVAILABLE).end();
+                }
+
                 let page = parseInt(req.query.page, 10);
                 let size = parseInt(req.query.size, 10);
 

--- a/destiny2/destiny2.routes.test.js
+++ b/destiny2/destiny2.routes.test.js
@@ -25,114 +25,151 @@ beforeAll(async () => {
 
     axiosAPIClient = axios.create(axiosConfig);
 
-    // ️️️Ensure that this component is isolated by preventing unknown calls.
+    // Ensure that this component is isolated by preventing unknown calls.
     nock.disableNetConnect();
     nock.enableNetConnect(ipAddress);
 });
 
+const get = async (url, options) => {
+    const delay = 1000; // milliseconds
+    let res;
+    let retries = 3;
+
+    while (retries > 0) {
+        res = await axiosAPIClient.get(url, options);
+
+        if (res.status !== StatusCodes.SERVICE_UNAVAILABLE) {
+            break;
+        }
+
+        retries -= 1;
+        await new Promise(resolve => setTimeout(resolve, delay));
+    }
+
+    return res;
+};
+
 describe('/destiny2', () => {
     describe('GET /destiny2/inventory', () => {
-        /**
-         * The intent of this test is to use async iterators to load a complete set of results by
-         * fetching page after page.
-         */
-        describe('when requesting the inventory of items with pagination', () => {
-            test('should receive a response with an array of items, HATEOAS links, and pagination statistics', async () => {
-                const items = [];
-                const limit = 15;
+        describe('when the server is not ready', async () => {
+            test('should receive a response with a 503 status code', async () => {
+                const res = await axiosAPIClient.get('/destiny2/inventory', {
+                    headers: configuration.notificationHeaders,
+                });
 
-                async function* pageThrough(url) {
-                    async function* get(_url) {
-                        const res = await axiosAPIClient.get(_url, {
-                            headers: configuration.notificationHeaders,
-                        });
-                        const page = res.data;
-
-                        yield page;
-
-                        if (res.data.links.next) {
-                            const { pathname, search } = new URL(res.data.links.next);
-
-                            yield* get(`${pathname}${search}`);
-                        }
-                    }
-
-                    yield* get(url);
-                }
-
-                async function* loadItems(url) {
-                    const result = pageThrough(url);
-
-                    for await (const page of result) {
-                        for (const item of page.data) {
-                            yield item;
-                        }
-                    }
-                }
-
-                for await (const item of loadItems('/destiny2/inventory?page=1&size=11')) {
-                    items.push(item);
-                    if (items.length >= limit) {
-                        break;
-                    }
-                }
-
-                expect(items.length).toEqual(limit);
+                expect(res).toMatchObject({
+                    status: StatusCodes.SERVICE_UNAVAILABLE,
+                });
             });
         });
 
-        /**
-         * The intent of this test is to successfully parse objects from an array delivered by a
-         * JSON stream. The test deliberately exits before processing the entire stream in order to
-         * finish before the default 5 second timeout.
-         */
-        describe('when requesting the inventory of items without pagination', () => {
-            test('should receive a response with an array of items', async () => {
-                const getResponse = await axiosAPIClient.get('/destiny2/inventory', {
-                    headers: configuration.notificationHeaders,
-                    responseType: 'stream',
+        describe('when the server is ready', async () => {
+            /**
+             * The intent of this test is to use async iterators to load a complete set of results by
+             * fetching page after page.
+             */
+            describe('when requesting the inventory of items with pagination', () => {
+                test('should receive a response with an array of items, HATEOAS links, and pagination statistics', async () => {
+                    const items = [];
+                    const limit = 15;
+    
+                    async function* pageThrough(url) {
+                        async function* fetchPage(_url) {
+                            const res = await get(_url, {
+                                headers: configuration.notificationHeaders,
+                            });
+                            const page = res.data;
+    
+                            yield page;
+    
+                            if (res.data.links.next) {
+                                const { pathname, search } = new URL(res.data.links.next);
+    
+                                yield* fetchPage(`${pathname}${search}`, {
+                                    headers: configuration.notificationHeaders,
+                                });
+                            }
+                        }
+    
+                        yield* fetchPage(url, {
+                            headers: configuration.notificationHeaders,
+                        });
+                    }
+    
+                    async function* loadItems(url) {
+                        const result = pageThrough(url);
+    
+                        for await (const page of result) {
+                            for (const item of page.data) {
+                                yield item;
+                            }
+                        }
+                    }
+    
+                    for await (const item of loadItems('/destiny2/inventory?page=1&size=11')) {
+                        items.push(item);
+                        if (items.length >= limit) {
+                            break;
+                        }
+                    }
+    
+                    expect(items.length).toEqual(limit);
                 });
-                const stream = getResponse.data;
-                const objectsStream = stream.pipe(StreamArray.withParser());
-                const items = [];
-
-                await new Promise((resolve, reject) => {
-                    objectsStream.on('data', data => {
-                        items.push(data.value);
-
-                        if (items.length > 1) resolve();
-                    });
-                    objectsStream.on('end', () => {
-                        resolve();
-                    });
-                    objectsStream.on('error', err => {
-                        reject(err);
-                    });
-                });
-
-                expect(getResponse).toMatchObject({
-                    status: StatusCodes.OK,
-                });
-                expect(items.length).toBeTruthy();
-                expect(items[0].displayProperties).toBeInstanceOf(Object);
             });
 
-            test('should stop streaming the response when the request is aborted', async () => {
-                const controller = new AbortController();
-                const { signal } = controller;
-
-                setTimeout(() => controller.abort(), 500);
-
-                try {
-                    await axiosAPIClient.get(`http://${ipAddress}:${process.env.PORT}/destiny2/inventory`, {
+            /**
+             * The intent of this test is to successfully parse objects from an array delivered by a
+             * JSON stream. The test deliberately exits before processing the entire stream in order to
+             * finish before the default 5 second timeout.
+             */
+            describe('when requesting the inventory of items without pagination', () => {
+                test('should receive a response with an array of items', async () => {
+                    const getResponse = await get('/destiny2/inventory', {
                         headers: configuration.notificationHeaders,
-                        signal,
+                        responseType: 'stream',
                     });
-                    
-                    throw new Error('Request should have been aborted');
-                } catch (err) {
-                    expect(err.name).toEqual('CanceledError');
-                }
+                    const stream = getResponse.data;
+                    const objectsStream = stream.pipe(StreamArray.withParser());
+                    const items = [];
+
+                    await new Promise((resolve, reject) => {
+                        objectsStream.on('data', data => {
+                            items.push(data.value);
+
+                            if (items.length > 1) resolve();
+                        });
+                        objectsStream.on('end', () => {
+                            resolve();
+                        });
+                        objectsStream.on('error', err => {
+                            reject(err);
+                        });
+                    });
+
+                    expect(getResponse).toMatchObject({
+                        status: StatusCodes.OK,
+                    });
+                    expect(items.length).toBeTruthy();
+                    expect(items[0].displayProperties).toBeInstanceOf(Object);
+                });
+
+                test('should stop streaming the response when the request is aborted', async () => {
+                    const controller = new AbortController();
+                    const { signal } = controller;
+
+                    setTimeout(() => controller.abort(), 500);
+
+                    try {
+                        await get(`http://${ipAddress}:${process.env.PORT}/destiny2/inventory`, {
+                            headers: configuration.notificationHeaders,
+                            signal,
+                        });
+                        
+                        throw new Error('Request should have been aborted');
+                    } catch (err) {
+                        expect(err.name).toEqual('CanceledError');
+                    }
+                });
             });
         });
     });

--- a/grpc.js
+++ b/grpc.js
@@ -3,6 +3,7 @@ import protoLoader from '@grpc/proto-loader';
 
 import configuration from './helpers/config';
 import World2 from './helpers/world2';
+import pool from './helpers/pool';
 
 let server;
 
@@ -17,6 +18,7 @@ const startServer = () => {
     const directory = process.env.DESTINY2_DATABASE_DIR;
     const world = new World2({
         directory,
+        pool,
     });
     const port = 1102;
 

--- a/helpers/pool.js
+++ b/helpers/pool.js
@@ -1,0 +1,8 @@
+import TinyPool from 'tinypool';
+
+const pool = new TinyPool({ filename: new URL('./worker.js', import.meta.url).href });
+
+const run = data => pool.run(data);
+const close = () => pool.destroy();
+
+export default { run, close };

--- a/helpers/worker.js
+++ b/helpers/worker.js
@@ -1,0 +1,13 @@
+import Database from 'better-sqlite3';
+
+export default async function ({ databasePath, queries }) {
+    const database = new Database(databasePath, {
+        readonly: true,
+        fileMustExist: true,
+    });
+    const results = queries.map(query => database.prepare(query).all());
+
+    database.close();
+
+    return results;
+}

--- a/helpers/world.spec.js
+++ b/helpers/world.spec.js
@@ -8,14 +8,18 @@ import {
 import World from './world';
 import itif from './itif';
 import { postmasterHash } from '../destiny/destiny.constants';
+import pool from './pool';
 
 const directory = process.env.DESTINY_DATABASE_DIR;
 let world;
 
-beforeAll(() => {
+beforeAll(async () => {
     world = new World({
         directory,
+        pool,
     });
+
+    await world.bootstrapped;
 });
 
 describe('It\'s Bungie\'s 1st world. You\'re just querying it.', () => {

--- a/helpers/world2.spec.js
+++ b/helpers/world2.spec.js
@@ -7,15 +7,19 @@ import {
 } from 'vitest';
 import World from './world2';
 import itif from './itif';
+import pool from './pool';
 import { xurHash } from '../destiny2/destiny2.constants';
 
 const directory = process.env.DESTINY2_DATABASE_DIR;
 let world;
 
-beforeAll(() => {
+beforeAll(async () => {
     world = new World({
         directory,
+        pool,
     });
+
+    await world.bootstrapped;
 });
 
 describe('It\'s Bungie\'s 2nd world. You\'re just querying it.', () => {

--- a/loaders/routes.js
+++ b/loaders/routes.js
@@ -32,6 +32,7 @@ import TwilioRouter from '../twilio/twilio.routes';
 import UserRouter from '../users/user.routes';
 import schema from '../graphql/schema';
 import root from '../graphql/root';
+import pool from '../helpers/pool';
 
 const {
     documents: {
@@ -84,9 +85,11 @@ export default () => {
 
     const world = new World({
         directory: process.env.DESTINY_DATABASE_DIR,
+        pool,
     });
     const world2 = new World2({
         directory: process.env.DESTINY2_DATABASE_DIR,
+        pool,
     });
     const destiny2Cache = new Destiny2Cache({ client });
     const destiny2Service = new Destiny2Service({ cacheService: destiny2Cache });

--- a/server.js
+++ b/server.js
@@ -14,6 +14,7 @@ import loaders from './loaders';
 import log from './helpers/log';
 import subscriber from './helpers/subscriber';
 import processExternalPromisesWithTimeout from './helpers/process-external-promises-with-timeout';
+import pool from './helpers/pool';
 
 let insecureConnection;
 let secureConnection;
@@ -58,6 +59,7 @@ const startServer = async () => {
             console.log('Interuption or termination signal received. Shutting down the server ...');
             await processExternalPromisesWithTimeout([
                 cache.quit(),
+                pool.close(),
                 subscriber.close(),
             ], 3000);
             insecureServer.close();


### PR DESCRIPTION
Reduce the start up time required to load the SQLite datasets from approximately 5 seconds to only a couple 100 milliseconds using Node worker threads.

Closes #444 