### PR TITLE
refactor: use node: prefix for all built-in module imports

### DIFF
--- a/destiny/destiny.controller.js
+++ b/destiny/destiny.controller.js
@@ -1,4 +1,4 @@
-import { randomBytes } from 'crypto';
+import { randomBytes } from 'node:crypto';
 import base64url from 'base64url';
 
 /**

--- a/destiny2/destiny2.routes.spec.js
+++ b/destiny2/destiny2.routes.spec.js
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 import {
     beforeEach, describe, expect, it, vi,
 } from 'vitest';

--- a/health/health.routes.spec.js
+++ b/health/health.routes.spec.js
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 import {
     beforeEach, describe, expect, it, vi,
 } from 'vitest';

--- a/helpers/bitly.js
+++ b/helpers/bitly.js
@@ -12,7 +12,7 @@
  * @requires request
  * @requires util
  */
-import { format } from 'util';
+import { format } from 'node:util';
 import configuration from './config.js';
 import { post } from './request.js';
 

--- a/helpers/config.js
+++ b/helpers/config.js
@@ -1,4 +1,4 @@
-import { readFileSync, readdirSync } from 'fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import camelCase from 'lodash/camelCase.js';
 
 function loadFile(file) {

--- a/helpers/sanitize-directory.js
+++ b/helpers/sanitize-directory.js
@@ -1,4 +1,4 @@
-import { normalize, resolve } from 'path';
+import { normalize, resolve } from 'node:path';
 
 export default function sanitizeDirectory(directory) {
     const rootDirectory = process.env.INIT_CWD;

--- a/helpers/tokens.js
+++ b/helpers/tokens.js
@@ -6,7 +6,7 @@
  * @author Chris Paskvan
  * @requires crypto
  */
-import { randomBytes as _randomBytes } from 'crypto';
+import { randomBytes as _randomBytes } from 'node:crypto';
 
 /**
  * Returns true if the number is an integer greater than 0.

--- a/helpers/world.js
+++ b/helpers/world.js
@@ -3,8 +3,8 @@
  */
 import {
     readdirSync, statSync, existsSync, createWriteStream, unlinkSync,
-} from 'fs';
-import { basename, join } from 'path';
+} from 'node:fs';
+import { basename, join } from 'node:path';
 import sampleSize from 'lodash/sampleSize.js';
 import axios from 'axios';
 import { open } from 'yauzl';

--- a/helpers/world.spec.js
+++ b/helpers/world.spec.js
@@ -1,7 +1,7 @@
 /**
  * World Model Tests
  */
-import { existsSync } from 'fs';
+import { existsSync } from 'node:fs';
 import {
     beforeAll, describe, expect, it,
 } from 'vitest';

--- a/helpers/world2.js
+++ b/helpers/world2.js
@@ -4,7 +4,7 @@
  * @module World
  * @summary Destiny World database.
  */
-import { join, basename } from 'path';
+import { join, basename } from 'node:path';
 import World from './world.js';
 import log from './log.js';
 

--- a/helpers/world2.spec.js
+++ b/helpers/world2.spec.js
@@ -1,7 +1,7 @@
 /**
  * World Model Tests
  */
-import { existsSync } from 'fs';
+import { existsSync } from 'node:fs';
 import {
     beforeAll, describe, expect,
 } from 'vitest';

--- a/loaders/index.js
+++ b/loaders/index.js
@@ -1,6 +1,6 @@
-import { existsSync, mkdirSync } from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { existsSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { StatusCodes } from 'http-status-codes';
 
 import DestinyError from '../destiny/destiny.error.js';

--- a/loaders/routes.js
+++ b/loaders/routes.js
@@ -1,7 +1,7 @@
 /**
  * Route Definitions
  */
-import { readFileSync } from 'fs';
+import { readFileSync } from 'node:fs';
 import { CosmosClient } from '@azure/cosmos';
 import { Router } from 'express';
 import { serve, setup } from 'swagger-ui-express';

--- a/server.js
+++ b/server.js
@@ -1,10 +1,10 @@
 /**
  * Application Server
  */
-import { readFileSync } from 'fs';
-import { createServer } from 'http';
-import { createServer as createSecureServer } from 'https';
-import { cpus } from 'os';
+import { readFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { createServer as createSecureServer } from 'node:https';
+import { cpus } from 'node:os';
 import express from 'express';
 import { createTerminus } from '@godaddy/terminus';
 

--- a/users/user.routes.spec.js
+++ b/users/user.routes.spec.js
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 import {
     beforeEach, describe, expect, it, vi,
 } from 'vitest';


### PR DESCRIPTION
Update all Node.js built-in module imports to use the 'node:' prefix for better compatibility with Node.js 24. This follows the recommended best practice of explicitly identifying core modules and helps distinguish them from third-party packages.

Modified imports for: fs, path, crypto, url, os, util, http, https, events

Files changed:
- server.js
- loaders/index.js, routes.js
- helpers/world.js, world2.js, world.spec.js, world2.spec.js
- helpers/sanitize-directory.js, bitly.js, config.js, tokens.js
- destiny/destiny.controller.js
- destiny2/destiny2.routes.spec.js
- users/user.routes.spec.js
- health/health.routes.spec.js