### PR TITLE
fix: normalize ESM import extensions to include .js across all source files

### DIFF
--- a/authentication/authentication.controller.spec.js
+++ b/authentication/authentication.controller.spec.js
@@ -2,8 +2,8 @@ import {
     beforeEach, describe, expect, it, vi,
 } from 'vitest';
 import Chance from 'chance';
-import AuthenticationController from './authentication.controller';
-import config from '../helpers/config';
+import AuthenticationController from './authentication.controller.js';
+import config from '../helpers/config.js';
 import usersJson from '../mocks/users.json';
 
 const [mockUser] = usersJson;

--- a/authentication/authentication.controller.spec.js
+++ b/authentication/authentication.controller.spec.js
@@ -8,7 +8,7 @@ import usersJson from '../mocks/users.json';
 
 const [mockUser] = usersJson;
 
-vi.mock('../helpers/request');
+vi.mock('../helpers/request.js');
 
 const chance = new Chance();
 const authenticationService = {

--- a/authentication/authentication.middleware.spec.js
+++ b/authentication/authentication.middleware.spec.js
@@ -2,7 +2,7 @@ import {
     describe, expect, it, vi,
 } from 'vitest';
 import { createRequest, createResponse } from 'node-mocks-http';
-import AuthenticationMiddleware from './authentication.middleware';
+import AuthenticationMiddleware from './authentication.middleware.js';
 
 describe('authorizeUser', () => {
     describe('when user is found', () => {

--- a/authentication/authentication.service.spec.js
+++ b/authentication/authentication.service.spec.js
@@ -5,7 +5,7 @@ import {
     afterEach, beforeEach, describe, expect, it, vi,
 } from 'vitest';
 import Chance from 'chance';
-import AuthenticationService from './authentication.service';
+import AuthenticationService from './authentication.service.js';
 import usersJson from '../mocks/users.json';
 
 const [mockUser] = usersJson;

--- a/authorization/authorization.middleware.spec.js
+++ b/authorization/authorization.middleware.spec.js
@@ -2,8 +2,8 @@ import {
     beforeEach, describe, expect, it, vi,
 } from 'vitest';
 import { createResponse, createRequest } from 'node-mocks-http';
-import configuration from '../helpers/config';
-import authorizeUser from './authorization.middleware';
+import configuration from '../helpers/config.js';
+import authorizeUser from './authorization.middleware.js';
 import { StatusCodes } from 'http-status-codes';
 
 describe('authorizeUser', () => {

--- a/destiny/destiny.cache.spec.js
+++ b/destiny/destiny.cache.spec.js
@@ -2,7 +2,7 @@ import {
     afterEach, beforeEach, describe, expect, it, vi,
 } from 'vitest';
 import RedisErrors from 'redis-errors';
-import DestinyCache from './destiny.cache';
+import DestinyCache from './destiny.cache.js';
 import mockManifestResponse from '../mocks/manifestResponse.json';
 import mockXurResponse from '../mocks/xurResponse.json';
 

--- a/destiny/destiny.routes.test.js
+++ b/destiny/destiny.routes.test.js
@@ -3,7 +3,7 @@ import { StatusCodes } from 'http-status-codes';
 import {
     afterAll, afterEach, beforeAll, describe, expect, test, vi,
 } from 'vitest';
-import { startServer, stopServer } from '../server';
+import { startServer, stopServer } from '../server.js';
 
 vi.mock('../helpers/subscriber');
 

--- a/destiny/destiny.routes.test.js
+++ b/destiny/destiny.routes.test.js
@@ -5,7 +5,7 @@ import {
 } from 'vitest';
 import { startServer, stopServer } from '../server.js';
 
-vi.mock('../helpers/subscriber');
+vi.mock('../helpers/subscriber.js');
 
 let baseUrl;
 const ipAddress = '127.0.0.1';

--- a/destiny/destiny.service.spec.js
+++ b/destiny/destiny.service.spec.js
@@ -5,9 +5,9 @@ import {
     beforeEach, describe, expect, it, vi,
 } from 'vitest';
 import Chance from 'chance';
-import { get } from '../helpers/request';
-import DestinyError from './destiny.error';
-import DestinyService from './destiny.service';
+import { get } from '../helpers/request.js';
+import DestinyError from './destiny.error.js';
+import DestinyService from './destiny.service.js';
 import mockManifestResponse from '../mocks/manifestResponse.json';
 
 vi.mock('../helpers/request');

--- a/destiny/destiny.service.spec.js
+++ b/destiny/destiny.service.spec.js
@@ -10,7 +10,7 @@ import DestinyError from './destiny.error.js';
 import DestinyService from './destiny.service.js';
 import mockManifestResponse from '../mocks/manifestResponse.json';
 
-vi.mock('../helpers/request');
+vi.mock('../helpers/request.js');
 
 let destinyService;
 

--- a/destiny2/destiny2.cache.spec.js
+++ b/destiny2/destiny2.cache.spec.js
@@ -1,7 +1,7 @@
 import {
     beforeEach, describe, expect, it, vi,
 } from 'vitest';
-import Destiny2Cache, { charactersExpiration, playerStatisticsExpiration } from './destiny2.cache';
+import Destiny2Cache, { charactersExpiration, playerStatisticsExpiration } from './destiny2.cache.js';
 import mockProfileCharactersResponse from '../mocks/profileCharactersResponse.json';
 import mockPlayerStatisticsResponse from '../mocks/playerStatisticsResponse.json';
 

--- a/destiny2/destiny2.controller.spec.js
+++ b/destiny2/destiny2.controller.spec.js
@@ -2,7 +2,7 @@ import {
     beforeEach, describe, expect, it, vi,
 } from 'vitest';
 import Chance from 'chance';
-import Destiny2Controller from './destiny2.controller';
+import Destiny2Controller from './destiny2.controller.js';
 import manifest2Response from '../mocks/manifest2Response.json';
 
 vi.mock('../helpers/request');

--- a/destiny2/destiny2.controller.spec.js
+++ b/destiny2/destiny2.controller.spec.js
@@ -5,7 +5,7 @@ import Chance from 'chance';
 import Destiny2Controller from './destiny2.controller.js';
 import manifest2Response from '../mocks/manifest2Response.json';
 
-vi.mock('../helpers/request');
+vi.mock('../helpers/request.js');
 
 const { Response: manifest } = manifest2Response;
 const chance = new Chance();

--- a/destiny2/destiny2.routes.spec.js
+++ b/destiny2/destiny2.routes.spec.js
@@ -6,7 +6,7 @@ import { StatusCodes } from 'http-status-codes';
 import Chance from 'chance';
 import { createResponse, createRequest } from 'node-mocks-http';
 
-import Destiny2Router from './destiny2.routes';
+import Destiny2Router from './destiny2.routes.js';
 import Destiny2Controller from './destiny2.controller.js';
 import manifest2Response from '../mocks/manifest2Response.json';
 

--- a/destiny2/destiny2.routes.test.js
+++ b/destiny2/destiny2.routes.test.js
@@ -8,7 +8,7 @@ import {
 import { startServer, stopServer } from '../server.js';
 import configuration from '../helpers/config.js';
 
-vi.mock('../helpers/subscriber');
+vi.mock('../helpers/subscriber.js');
 
 let baseUrl;
 const ipAddress = '127.0.0.1';

--- a/destiny2/destiny2.routes.test.js
+++ b/destiny2/destiny2.routes.test.js
@@ -5,8 +5,8 @@ import { Readable } from 'node:stream';
 import {
     afterAll, afterEach, beforeAll, describe, expect, test, vi,
 } from 'vitest';
-import { startServer, stopServer } from '../server';
-import configuration from '../helpers/config';
+import { startServer, stopServer } from '../server.js';
+import configuration from '../helpers/config.js';
 
 vi.mock('../helpers/subscriber');
 

--- a/destiny2/destiny2.service.spec.js
+++ b/destiny2/destiny2.service.spec.js
@@ -4,13 +4,13 @@
 import {
     beforeEach, describe, expect, it, vi,
 } from 'vitest';
-import Destiny2Service from './destiny2.service';
-import DestinyError from '../destiny/destiny.error';
+import Destiny2Service from './destiny2.service.js';
+import DestinyError from '../destiny/destiny.error.js';
 import mockManifestResponse from '../mocks/manifestResponse.json';
 import mockProfileCharactersResponse from '../mocks/profileCharactersResponse.json';
 import mockPlayerStatisticsResponse from '../mocks/playerStatisticsResponse.json';
 import mockXurResponse from '../mocks/xurResponse.json';
-import { get, post } from '../helpers/request';
+import { get, post } from '../helpers/request.js';
 
 vi.mock('../helpers/request');
 

--- a/destiny2/destiny2.service.spec.js
+++ b/destiny2/destiny2.service.spec.js
@@ -12,7 +12,7 @@ import mockPlayerStatisticsResponse from '../mocks/playerStatisticsResponse.json
 import mockXurResponse from '../mocks/xurResponse.json';
 import { get, post } from '../helpers/request.js';
 
-vi.mock('../helpers/request');
+vi.mock('../helpers/request.js');
 
 const mockUser = {
     membershipId: '11',

--- a/graphql/root.spec.js
+++ b/graphql/root.spec.js
@@ -2,7 +2,7 @@ import Chance from 'chance';
 import {
     describe, expect, it, vi,
 } from 'vitest';
-import root from './root';
+import root from './root.js';
 
 vi.mock('../helpers/throttle');
 

--- a/graphql/root.spec.js
+++ b/graphql/root.spec.js
@@ -4,7 +4,7 @@ import {
 } from 'vitest';
 import root from './root.js';
 
-vi.mock('../helpers/throttle');
+vi.mock('../helpers/throttle.js');
 
 const chance = new Chance();
 const mockPlayer = {

--- a/health/health.controller.spec.js
+++ b/health/health.controller.spec.js
@@ -1,9 +1,9 @@
 import {
     beforeEach, describe, expect, it, vi,
 } from 'vitest';
-import { get } from '../helpers/request';
-import applicationInsights from '../helpers/application-insights';
-import HealthController from './health.controller';
+import { get } from '../helpers/request.js';
+import applicationInsights from '../helpers/application-insights.js';
+import HealthController from './health.controller.js';
 import manifestResponse from '../mocks/manifestResponse.json';
 import manifest2Response from '../mocks/manifest2Response.json';
 

--- a/health/health.controller.spec.js
+++ b/health/health.controller.spec.js
@@ -7,13 +7,13 @@ import HealthController from './health.controller.js';
 import manifestResponse from '../mocks/manifestResponse.json';
 import manifest2Response from '../mocks/manifest2Response.json';
 
-vi.mock('../helpers/request');
-vi.mock('../helpers/application-insights', () => ({
+vi.mock('../helpers/request.js');
+vi.mock('../helpers/application-insights.js', () => ({
     default: {
         trackMetric: vi.fn(),
     },
 }));
-vi.mock('../helpers/log', () => ({
+vi.mock('../helpers/log.js', () => ({
     default: {
         error: vi.fn(),
         info: vi.fn(),

--- a/health/health.routes.spec.js
+++ b/health/health.routes.spec.js
@@ -4,8 +4,8 @@ import {
 } from 'vitest';
 import { StatusCodes } from 'http-status-codes';
 import { createResponse, createRequest } from 'node-mocks-http';
-import { get } from '../helpers/request';
-import HealthRouter from './health.routes';
+import { get } from '../helpers/request.js';
+import HealthRouter from './health.routes.js';
 import manifestResponse from '../mocks/manifestResponse.json';
 import manifest2Response from '../mocks/manifest2Response.json';
 

--- a/health/health.routes.spec.js
+++ b/health/health.routes.spec.js
@@ -9,7 +9,7 @@ import HealthRouter from './health.routes.js';
 import manifestResponse from '../mocks/manifestResponse.json';
 import manifest2Response from '../mocks/manifest2Response.json';
 
-vi.mock('../helpers/request');
+vi.mock('../helpers/request.js');
 
 const { Response: manifest } = manifestResponse;
 const { Response: manifest2 } = manifest2Response;

--- a/helpers/ai.js
+++ b/helpers/ai.js
@@ -1,6 +1,6 @@
 import { GoogleGenAI } from '@google/genai';
-import configuration from './config';
-import log from './log';
+import configuration from './config.js';
+import log from './log.js';
 import { withRetry, isTransientError } from './retry.js';
 
 const { gemini: { apiKey, model } } = configuration;

--- a/helpers/ai.spec.js
+++ b/helpers/ai.spec.js
@@ -8,7 +8,7 @@ vi.mock('@google/genai', () => ({
         models = { generateContent: vi.fn() };
     },
 }));
-vi.mock('./config', () => ({
+vi.mock('./config.js', () => ({
     default: {
         gemini: {
             apiKey: 'test-api-key',
@@ -16,7 +16,7 @@ vi.mock('./config', () => ({
         },
     },
 }));
-vi.mock('./log', () => ({
+vi.mock('./log.js', () => ({
     default: {
         info: vi.fn(),
         warn: vi.fn(),

--- a/helpers/ai.spec.js
+++ b/helpers/ai.spec.js
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import aiInstance from './ai';
+import aiInstance from './ai.js';
 import { withRetry, isTransientError } from './retry.js';
 
 vi.mock('@google/genai', () => ({

--- a/helpers/claim-check.spec.js
+++ b/helpers/claim-check.spec.js
@@ -1,8 +1,8 @@
 import {
     describe, expect, it, beforeEach, afterEach, vi,
 } from 'vitest';
-import ClaimCheck, { claimCheckExpiration } from './claim-check';
-import cache from './cache';
+import ClaimCheck, { claimCheckExpiration } from './claim-check.js';
+import cache from './cache.js';
 
 vi.mock('./cache', () => ({
     default: {

--- a/helpers/claim-check.spec.js
+++ b/helpers/claim-check.spec.js
@@ -4,7 +4,7 @@ import {
 import ClaimCheck, { claimCheckExpiration } from './claim-check.js';
 import cache from './cache.js';
 
-vi.mock('./cache', () => ({
+vi.mock('./cache.js', () => ({
     default: {
         hSet: vi.fn(),
         hGet: vi.fn(),

--- a/helpers/director.client.js
+++ b/helpers/director.client.js
@@ -1,4 +1,4 @@
-import { post } from './request';
+import { post } from './request.js';
 
 class DirectorClient {
     query = 'query FindPlayersHeroNameAndFriends($displayName: String!) { findPlayers(displayName: $displayName) { bungieGlobalDisplayName bungieGlobalDisplayNameCode destinyMemberships { crossSaveOverride membershipType membershipId displayName bungieGlobalDisplayName bungieGlobalDisplayNameCode } destinyMemberships { crossSaveOverride membershipType membershipId displayName bungieGlobalDisplayName bungieGlobalDisplayNameCode } statistics { pvp { kdr highestLightLevel } } user { firstName lastName } } }';

--- a/helpers/director.client.spec.js
+++ b/helpers/director.client.spec.js
@@ -20,7 +20,7 @@ describe('DirectorClient', () => {
     beforeEach(async () => {
         vi.clearAllMocks();
 
-        const requestModule = await import('./request');
+        const requestModule = await import('./request.js');
 
         mockPost = requestModule.post;
         directorClient = new DirectorClient();

--- a/helpers/director.client.spec.js
+++ b/helpers/director.client.spec.js
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import DirectorClient from './director.client.js';
 
-vi.mock('./request', () => ({
+vi.mock('./request.js', () => ({
     post: vi.fn(),
 }));
 

--- a/helpers/director.client.spec.js
+++ b/helpers/director.client.spec.js
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import DirectorClient from './director.client';
+import DirectorClient from './director.client.js';
 
 vi.mock('./request', () => ({
     post: vi.fn(),

--- a/helpers/documents.spec.js
+++ b/helpers/documents.spec.js
@@ -4,8 +4,8 @@
 import {
     describe, expect, it, vi,
 } from 'vitest';
-import QueryBuilder from './queryBuilder';
-import Documents from './documents';
+import QueryBuilder from './queryBuilder.js';
+import Documents from './documents.js';
 
 describe('Documents', () => {
     const collectionId = 'Messages';

--- a/helpers/get-max-age-from-cache-control.spec.js
+++ b/helpers/get-max-age-from-cache-control.spec.js
@@ -1,7 +1,7 @@
 import {
     describe, expect, it,
 } from 'vitest';
-import getMaxAgeFromCacheControl from './get-max-age-from-cache-control';
+import getMaxAgeFromCacheControl from './get-max-age-from-cache-control.js';
 
 describe('getMaxAgeFromCacheControl()', () => {
     describe('when max-age is included and is a number', () => {

--- a/helpers/idempotency-keys.spec.js
+++ b/helpers/idempotency-keys.spec.js
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import cache from './cache.js';
 import { getIdempotencyKey, setIdempotencyKey } from './idempotency-keys.js';
 
-vi.mock('./cache');
+vi.mock('./cache.js');
 
 describe('idempotency-keys', () => {
     beforeEach(() => {

--- a/helpers/idempotency-keys.spec.js
+++ b/helpers/idempotency-keys.spec.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import cache from './cache';
-import { getIdempotencyKey, setIdempotencyKey } from './idempotency-keys';
+import cache from './cache.js';
+import { getIdempotencyKey, setIdempotencyKey } from './idempotency-keys.js';
 
 vi.mock('./cache');
 

--- a/helpers/postmaster.spec.js
+++ b/helpers/postmaster.spec.js
@@ -4,7 +4,7 @@
 import {
     describe, expect, it, vi, beforeEach,
 } from 'vitest';
-import Postmaster from './postmaster';
+import Postmaster from './postmaster.js';
 import users from '../mocks/users.json';
 import { withRetry } from './retry.js';
 

--- a/helpers/process-external-promises-with-timeout.spec.js
+++ b/helpers/process-external-promises-with-timeout.spec.js
@@ -2,7 +2,7 @@ import {
     describe, expect, it,
 } from 'vitest';
 
-import processExternalPromisesWithTimeout from './process-external-promises-with-timeout';
+import processExternalPromisesWithTimeout from './process-external-promises-with-timeout.js';
 
 describe('processExternalPromisesWithTimeout', () => {
     it('should resolve all promises within the timeout', async () => {

--- a/helpers/publisher.spec.js
+++ b/helpers/publisher.spec.js
@@ -12,7 +12,7 @@ vi.mock('bullmq', () => ({
     },
 }));
 
-import publisher from './publisher';
+import publisher from './publisher.js';
 
 const chance = new Chance();
 

--- a/helpers/queryBuilder.spec.js
+++ b/helpers/queryBuilder.spec.js
@@ -4,7 +4,7 @@
 import {
     describe, expect, it,
 } from 'vitest';
-import QueryBuilder from './queryBuilder';
+import QueryBuilder from './queryBuilder.js';
 
 describe('QueryBuilder', () => {
     it('should select all fields from root where userName matches criteria', () => {

--- a/helpers/sanitize-directory.spec.js
+++ b/helpers/sanitize-directory.spec.js
@@ -3,7 +3,7 @@ import { sep } from 'node:path';
 import {
     afterEach, beforeEach, describe, expect, it, vi,
 } from 'vitest';
-import sanitizeDirectory from './sanitize-directory';
+import sanitizeDirectory from './sanitize-directory.js';
 
 vi.mock('node:fs', () => ({
     realpathSync: vi.fn(),

--- a/helpers/subscriber.spec.js
+++ b/helpers/subscriber.spec.js
@@ -20,7 +20,7 @@ vi.mock('./log.js', () => ({
     },
 }));
 
-import subscriber from './subscriber';
+import subscriber from './subscriber.js';
 
 describe('Subscriber', () => {
     let MockWorkerConstructor;

--- a/helpers/throttle.spec.js
+++ b/helpers/throttle.spec.js
@@ -4,7 +4,7 @@
 import {
     afterEach, beforeEach, describe, expect, it, vi,
 } from 'vitest';
-import throttle from './throttle';
+import throttle from './throttle.js';
 
 describe('throttle()', () => {
     describe('when throttling tasks', () => {

--- a/helpers/to-temporal-instant.spec.js
+++ b/helpers/to-temporal-instant.spec.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import toTemporalInstant from './to-temporal-instant';
+import toTemporalInstant from './to-temporal-instant.js';
 
 describe('toTemporalInstant', () => {
     describe('when given a valid HTTP date string', () => {

--- a/helpers/tokens.spec.js
+++ b/helpers/tokens.spec.js
@@ -4,7 +4,7 @@
 import {
     describe, expect, it,
 } from 'vitest';
-import { getBlob, getCode } from './tokens';
+import { getBlob, getCode } from './tokens.js';
 
 describe('Tokens', () => {
     describe('getBlob', () => {

--- a/helpers/worker.spec.js
+++ b/helpers/worker.spec.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import Database from 'better-sqlite3';
-import worker from './worker';
+import worker from './worker.js';
 
 vi.mock('better-sqlite3', () => ({
     default: vi.fn(),

--- a/helpers/world.spec.js
+++ b/helpers/world.spec.js
@@ -5,10 +5,10 @@ import { existsSync } from 'node:fs';
 import {
     afterEach, beforeAll, describe, expect, it, vi,
 } from 'vitest';
-import World from './world';
-import itif from './itif';
-import { postmasterHash } from '../destiny/destiny.constants';
-import pool from './pool';
+import World from './world.js';
+import itif from './itif.js';
+import { postmasterHash } from '../destiny/destiny.constants.js';
+import pool from './pool.js';
 
 vi.mock('node:fs', async importOriginal => {
     const actual = await importOriginal();

--- a/helpers/world2.spec.js
+++ b/helpers/world2.spec.js
@@ -5,10 +5,10 @@ import { existsSync } from 'node:fs';
 import {
     beforeAll, describe, expect,
 } from 'vitest';
-import World from './world2';
-import itif from './itif';
-import pool from './pool';
-import { xurHash } from '../destiny2/destiny2.constants';
+import World from './world2.js';
+import itif from './itif.js';
+import pool from './pool.js';
+import { xurHash } from '../destiny2/destiny2.constants.js';
 
 const directory = process.env.DESTINY2_DATABASE_DIR;
 let world;

--- a/notifications/notification.controller.spec.js
+++ b/notifications/notification.controller.spec.js
@@ -2,14 +2,14 @@ import {
     beforeEach, describe, expect, it, vi,
 } from 'vitest';
 import Chance from 'chance';
-import publisher from '../helpers/publisher';
-import subscriber from '../helpers/subscriber';
-import NotificationController from './notification.controller';
-import NotificationError from './notification.error';
-import notificationTypes from './notification.types';
-import ClaimCheck from '../helpers/claim-check';
-import log from '../helpers/log';
-import throttle from '../helpers/throttle';
+import publisher from '../helpers/publisher.js';
+import subscriber from '../helpers/subscriber.js';
+import NotificationController from './notification.controller.js';
+import NotificationError from './notification.error.js';
+import notificationTypes from './notification.types.js';
+import ClaimCheck from '../helpers/claim-check.js';
+import log from '../helpers/log.js';
+import throttle from '../helpers/throttle.js';
 
 vi.mock('../helpers/publisher');
 vi.mock('../helpers/subscriber');

--- a/notifications/notification.controller.spec.js
+++ b/notifications/notification.controller.spec.js
@@ -11,17 +11,17 @@ import ClaimCheck from '../helpers/claim-check.js';
 import log from '../helpers/log.js';
 import throttle from '../helpers/throttle.js';
 
-vi.mock('../helpers/publisher');
-vi.mock('../helpers/subscriber');
-vi.mock('./notification.error');
-vi.mock('../helpers/claim-check');
-vi.mock('../helpers/log', () => ({
+vi.mock('../helpers/publisher.js');
+vi.mock('../helpers/subscriber.js');
+vi.mock('./notification.error.js');
+vi.mock('../helpers/claim-check.js');
+vi.mock('../helpers/log.js', () => ({
     default: {
         info: vi.fn(),
         error: vi.fn(),
     },
 }));
-vi.mock('../helpers/throttle');
+vi.mock('../helpers/throttle.js');
 
 const chance = new Chance();
 const phoneNumber = chance.phone();

--- a/notifications/notification.service.spec.js
+++ b/notifications/notification.service.spec.js
@@ -2,7 +2,7 @@ import {
     beforeEach, describe, expect, it, vi,
 } from 'vitest';
 import mockTwilioCreateMessageResponse from '../mocks/twilioCreateMessageResponse.json';
-import Notifications from './notification.service';
+import Notifications from './notification.service.js';
 import { withRetry, isTransientError } from '../helpers/retry.js';
 
 vi.mock('../helpers/retry.js', () => ({

--- a/users/user.cache.spec.js
+++ b/users/user.cache.spec.js
@@ -1,7 +1,7 @@
 import {
     afterEach, beforeEach, describe, expect, it, vi,
 } from 'vitest';
-import UserCache from './user.cache';
+import UserCache from './user.cache.js';
 import mockUsers from '../mocks/users.json';
 
 const [mockUser] = mockUsers;

--- a/users/user.controller.spec.js
+++ b/users/user.controller.spec.js
@@ -5,7 +5,7 @@ import Chance from 'chance';
 import getEpoch from '../helpers/get-epoch.js';
 import UserController from './user.controller.js';
 
-vi.mock('../helpers/postmaster', () => ({
+vi.mock('../helpers/postmaster.js', () => ({
     default: class {
         register = vi.fn();
     },

--- a/users/user.controller.spec.js
+++ b/users/user.controller.spec.js
@@ -2,8 +2,8 @@ import {
     beforeEach, describe, expect, it, vi,
 } from 'vitest';
 import Chance from 'chance';
-import getEpoch from '../helpers/get-epoch';
-import UserController from './user.controller';
+import getEpoch from '../helpers/get-epoch.js';
+import UserController from './user.controller.js';
 
 vi.mock('../helpers/postmaster', () => ({
     default: class {

--- a/users/user.routes.spec.js
+++ b/users/user.routes.spec.js
@@ -7,16 +7,16 @@ import Chance from 'chance';
 import { createResponse, createRequest } from 'node-mocks-http';
 import UserRouter from './user.routes.js';
 
-vi.mock('../helpers/postmaster', () => ({
+vi.mock('../helpers/postmaster.js', () => ({
     default: class {
         confirm = vi.fn().mockResolvedValue({ messageId: 'test-email-id' });
     },
 }));
-vi.mock('../helpers/tokens', () => ({
+vi.mock('../helpers/tokens.js', () => ({
     getBlob: vi.fn(() => 'test-blob-token'),
     getCode: vi.fn(() => '123456'),
 }));
-vi.mock('../helpers/get-epoch', () => ({
+vi.mock('../helpers/get-epoch.js', () => ({
     default: vi.fn(() => Math.floor(Temporal.Now.instant().epochMilliseconds / 1000)),
 }));
 

--- a/users/user.routes.spec.js
+++ b/users/user.routes.spec.js
@@ -5,7 +5,7 @@ import {
 import { StatusCodes } from 'http-status-codes';
 import Chance from 'chance';
 import { createResponse, createRequest } from 'node-mocks-http';
-import UserRouter from './user.routes';
+import UserRouter from './user.routes.js';
 
 vi.mock('../helpers/postmaster', () => ({
     default: class {

--- a/users/user.service.spec.js
+++ b/users/user.service.spec.js
@@ -5,7 +5,7 @@ import {
     afterEach, beforeEach, describe, expect, it, vi,
 } from 'vitest';
 import Chance from 'chance';
-import UserService from './user.service';
+import UserService from './user.service.js';
 
 const cacheService = {
     getUser: vi.fn(),


### PR DESCRIPTION
Closes #572

## Summary
- Added `.js` extension to all 69 bare relative import specifiers across 41 source and spec files
- Ensures compliance with Node.js ESM module resolution, which requires explicit file extensions

## Test plan
- [x] All 45 test files pass (438 tests, 1 skipped)
- [x] ESLint passes (run automatically via pre-commit hook)
- [x] No bare relative specifiers remain in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)