### PR TITLE
fix: enable retries on safe downstream POST requests

### DIFF
--- a/destiny/destiny.service.js
+++ b/destiny/destiny.service.js
@@ -113,7 +113,7 @@ class DestinyService {
             url: `${servicePlatform}/app/oauth/token/`,
         };
 
-        return await post(options);
+        return await post(options, { maxRetries: 3 });
     }
 
     /**

--- a/destiny2/destiny2.service.js
+++ b/destiny2/destiny2.service.js
@@ -52,7 +52,7 @@ class Destiny2Service extends DestinyService {
             },
             url: `${servicePlatform}/User/Search/GlobalName/${pageNumber}/`,
         };
-        const responseBody = await post(options);
+        const responseBody = await post(options, { maxRetries: 3 });
 
         if (responseBody.ErrorCode === 1) {
             const { Response: { searchResults } } = responseBody;

--- a/helpers/bitly.js
+++ b/helpers/bitly.js
@@ -38,7 +38,7 @@ async function getShortUrl(longUrl) {
         return Promise.reject(new Error('URL is not a string'));
     }
 
-    const { link: shortUrl } = await post(options);
+    const { link: shortUrl } = await post(options, { maxRetries: 3 });
 
     return shortUrl;
 }

--- a/helpers/bitly.spec.js
+++ b/helpers/bitly.spec.js
@@ -48,7 +48,7 @@ describe('Bitly', () => {
                 headers: {
                     Authorization: 'Bearer test-access-token',
                 },
-            }));
+            }), { maxRetries: 3 });
         });
 
         it('should reject when URL is not a string', async () => {


### PR DESCRIPTION
## Summary
- Enable `maxRetries: 3` on downstream POST requests that are safe to retry: Bungie OAuth token exchange, Bungie player search, and Bitly URL shortening
- Previously all `post()` calls defaulted to `maxRetries: 0` (no retries), while `get()` calls already had `maxRetries: 3`
- Each POST endpoint was evaluated for idempotency before enabling retries

## Analysis

| # | Service | Endpoint | Decision | Rationale |
|---|---------|----------|----------|-----------|
| 1 | Bungie OAuth | `/platform/app/oauth/token/` | **Retry** | Auth code is single-use; failed retry returns non-transient error |
| 2 | Bungie Search | `/Platform/User/Search/GlobalName/` | **Retry** | Read-only query via POST, no side effects |
| 3 | Bitly | `/v4/shorten` | **Retry** | Naturally idempotent — same long URL returns same short URL |
| 4 | Director GraphQL | `api2.destiny-ghost.com/director` | **No change** | Internal API — caller should own retry strategy |
| 5 | Twilio SMS | `client.messages.create` | **No change** | No idempotency support; retries would send duplicate texts |
| 6 | SMTP Email | `transporter.sendMail` | **No change** | Already has `maxRetries: 1` scoped to connection errors |

Closes #575

## Test plan
- [x] All existing tests pass (438 passed, 1 skipped)
- [x] Updated Bitly test to assert new `maxRetries` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)