### PR TITLE
feat: add pagination to ItemService/GetAll gRPC endpoint

### DIFF
--- a/grpc.js
+++ b/grpc.js
@@ -25,18 +25,32 @@ const startServer = () => {
     server = new grpc.Server();
     server.addService(itemsProto.ItemService.service, {
         getAll: (call, callback) => {
-            Object.entries(configuration.notificationHeaders).forEach(entry => {
-                const [key, value1] = entry;
+            for (const [key, value1] of Object.entries(configuration.notificationHeaders)) {
                 const [value2] = call.metadata.get(key);
 
                 if (value1 !== value2) {
-                    callback({
-                        code: grpc.status.UNAUTHENTICATED,
-                    });
+                    return callback({ code: grpc.status.UNAUTHENTICATED });
                 }
-            });
+            }
 
-            callback(null, { items: world.items });
+            const items = world.items;
+            const page = call.request.page || 1;
+            const size = call.request.size || 11;
+            const pages = Math.ceil(items.length / size);
+            const data = items.slice((page - 1) * size, page * size);
+
+            callback(null, {
+                data,
+                links: {
+                    next: page < pages ? String(page + 1) : '',
+                },
+                page: {
+                    size,
+                    total: items.length,
+                    pages,
+                    number: page,
+                },
+            });
         },
     });
 

--- a/grpc.js
+++ b/grpc.js
@@ -7,32 +7,44 @@ import pool from './helpers/pool.js';
 
 let server;
 
-const createGetAllHandler = (world) => (call, callback) => {
+const createGetAllHandler = world => (call, callback) => {
     for (const [key, value1] of Object.entries(configuration.notificationHeaders)) {
         const [value2] = call.metadata.get(key);
 
         if (value1 !== value2) {
-            return callback({ code: grpc.status.UNAUTHENTICATED });
+            return callback({
+                code: grpc.status.UNAUTHENTICATED,
+                message: `Invalid or missing metadata for "${key}".`,
+            });
         }
     }
 
     const items = world.items;
 
     if (!items?.length) {
-        return callback({ code: grpc.status.UNAVAILABLE });
+        return callback({
+            code: grpc.status.UNAVAILABLE,
+            message: 'No items are currently available.',
+        });
     }
 
     const page = call.request.page ?? 1;
     const size = call.request.size ?? 11;
 
     if (page < 1 || size < 1) {
-        return callback({ code: grpc.status.INVALID_ARGUMENT });
+        return callback({
+            code: grpc.status.INVALID_ARGUMENT,
+            message: 'page and size must be greater than or equal to 1.',
+        });
     }
 
     const pages = Math.ceil(items.length / size);
 
     if (page > pages) {
-        return callback({ code: grpc.status.OUT_OF_RANGE });
+        return callback({
+            code: grpc.status.OUT_OF_RANGE,
+            message: `Requested page ${page} exceeds available pages (${pages}).`,
+        });
     }
 
     const data = items.slice((page - 1) * size, page * size);
@@ -40,7 +52,7 @@ const createGetAllHandler = (world) => (call, callback) => {
     callback(null, {
         data,
         links: {
-            next: page < pages ? String(page + 1) : '',
+            next_page: page < pages ? String(page + 1) : '',
         },
         page: {
             size,

--- a/grpc.js
+++ b/grpc.js
@@ -41,9 +41,8 @@ const startServer = () => {
 
             const page = call.request.page || 1;
             const size = call.request.size || 11;
-            const MAX_SIZE = 100;
 
-            if (page < 1 || size < 1 || size > MAX_SIZE) {
+            if (page < 1 || size < 1) {
                 return callback({ code: grpc.status.INVALID_ARGUMENT });
             }
 

--- a/grpc.js
+++ b/grpc.js
@@ -39,8 +39,8 @@ const startServer = () => {
                 return callback({ code: grpc.status.UNAVAILABLE });
             }
 
-            const page = call.request.page || 1;
-            const size = call.request.size || 11;
+            const page = call.request.page ?? 1;
+            const size = call.request.size ?? 11;
 
             if (page < 1 || size < 1) {
                 return callback({ code: grpc.status.INVALID_ARGUMENT });

--- a/grpc.js
+++ b/grpc.js
@@ -7,6 +7,50 @@ import pool from './helpers/pool.js';
 
 let server;
 
+const createGetAllHandler = (world) => (call, callback) => {
+    for (const [key, value1] of Object.entries(configuration.notificationHeaders)) {
+        const [value2] = call.metadata.get(key);
+
+        if (value1 !== value2) {
+            return callback({ code: grpc.status.UNAUTHENTICATED });
+        }
+    }
+
+    const items = world.items;
+
+    if (!items?.length) {
+        return callback({ code: grpc.status.UNAVAILABLE });
+    }
+
+    const page = call.request.page ?? 1;
+    const size = call.request.size ?? 11;
+
+    if (page < 1 || size < 1) {
+        return callback({ code: grpc.status.INVALID_ARGUMENT });
+    }
+
+    const pages = Math.ceil(items.length / size);
+
+    if (page > pages) {
+        return callback({ code: grpc.status.OUT_OF_RANGE });
+    }
+
+    const data = items.slice((page - 1) * size, page * size);
+
+    callback(null, {
+        data,
+        links: {
+            next: page < pages ? String(page + 1) : '',
+        },
+        page: {
+            size,
+            total: items.length,
+            pages,
+            number: page,
+        },
+    });
+};
+
 const startServer = () => {
     const packageDefinition = protoLoader.loadSync('./items.proto', {
         keepCase: true,
@@ -24,49 +68,7 @@ const startServer = () => {
 
     server = new grpc.Server();
     server.addService(itemsProto.ItemService.service, {
-        getAll: (call, callback) => {
-            for (const [key, value1] of Object.entries(configuration.notificationHeaders)) {
-                const [value2] = call.metadata.get(key);
-
-                if (value1 !== value2) {
-                    return callback({ code: grpc.status.UNAUTHENTICATED });
-                }
-            }
-
-            const items = world.items;
-
-            if (!items?.length) {
-                return callback({ code: grpc.status.UNAVAILABLE });
-            }
-
-            const page = call.request.page ?? 1;
-            const size = call.request.size ?? 11;
-
-            if (page < 1 || size < 1) {
-                return callback({ code: grpc.status.INVALID_ARGUMENT });
-            }
-
-            const pages = Math.ceil(items.length / size);
-
-            if (page > pages) {
-                return callback({ code: grpc.status.OUT_OF_RANGE });
-            }
-
-            const data = items.slice((page - 1) * size, page * size);
-
-            callback(null, {
-                data,
-                links: {
-                    next: page < pages ? String(page + 1) : '',
-                },
-                page: {
-                    size,
-                    total: items.length,
-                    pages,
-                    number: page,
-                },
-            });
-        },
+        getAll: createGetAllHandler(world),
     });
 
     server.bindAsync(`127.0.0.1:${port}`, grpc.ServerCredentials.createInsecure(), () => {
@@ -79,6 +81,7 @@ const stopServer = () => {
 };
 
 export {
+    createGetAllHandler,
     startServer,
     stopServer,
 };

--- a/grpc.js
+++ b/grpc.js
@@ -34,9 +34,25 @@ const startServer = () => {
             }
 
             const items = world.items;
+
+            if (!items?.length) {
+                return callback({ code: grpc.status.UNAVAILABLE });
+            }
+
             const page = call.request.page || 1;
             const size = call.request.size || 11;
+            const MAX_SIZE = 100;
+
+            if (page < 1 || size < 1 || size > MAX_SIZE) {
+                return callback({ code: grpc.status.INVALID_ARGUMENT });
+            }
+
             const pages = Math.ceil(items.length / size);
+
+            if (page > pages) {
+                return callback({ code: grpc.status.OUT_OF_RANGE });
+            }
+
             const data = items.slice((page - 1) * size, page * size);
 
             callback(null, {

--- a/grpc.spec.js
+++ b/grpc.spec.js
@@ -12,9 +12,9 @@ vi.mock('./helpers/config.js', () => ({
 vi.mock('./helpers/pool.js', () => ({ default: {} }));
 vi.mock('./helpers/world2.js', () => ({ default: vi.fn() }));
 
-const createCall = ({ headerValue = 'test-value', page = null, size = null } = {}) => ({
+const createCall = ({ headerValue = 'test-value', page = undefined, size = undefined } = {}) => ({
     metadata: {
-        get: (key) => (key === 'x-test-header' ? [headerValue] : []),
+        get: key => (key === 'x-test-header' ? [headerValue] : []),
     },
     request: { page, size },
 });
@@ -34,7 +34,10 @@ describe('createGetAllHandler', () => {
 
             handler(createCall({ headerValue: 'wrong' }), callback);
 
-            expect(callback).toHaveBeenCalledWith({ code: grpc.status.UNAUTHENTICATED });
+            expect(callback).toHaveBeenCalledWith({
+                code: grpc.status.UNAUTHENTICATED,
+                message: 'Invalid or missing metadata for "x-test-header".',
+            });
         });
     });
 
@@ -44,7 +47,10 @@ describe('createGetAllHandler', () => {
 
             handler(createCall(), callback);
 
-            expect(callback).toHaveBeenCalledWith({ code: grpc.status.UNAVAILABLE });
+            expect(callback).toHaveBeenCalledWith({
+                code: grpc.status.UNAVAILABLE,
+                message: 'No items are currently available.',
+            });
         });
 
         it('returns UNAVAILABLE when items is empty', () => {
@@ -52,7 +58,10 @@ describe('createGetAllHandler', () => {
 
             handler(createCall(), callback);
 
-            expect(callback).toHaveBeenCalledWith({ code: grpc.status.UNAVAILABLE });
+            expect(callback).toHaveBeenCalledWith({
+                code: grpc.status.UNAVAILABLE,
+                message: 'No items are currently available.',
+            });
         });
     });
 
@@ -62,7 +71,10 @@ describe('createGetAllHandler', () => {
 
             handler(createCall({ page: 0 }), callback);
 
-            expect(callback).toHaveBeenCalledWith({ code: grpc.status.INVALID_ARGUMENT });
+            expect(callback).toHaveBeenCalledWith({
+                code: grpc.status.INVALID_ARGUMENT,
+                message: 'page and size must be greater than or equal to 1.',
+            });
         });
 
         it('returns INVALID_ARGUMENT when size is 0', () => {
@@ -70,7 +82,10 @@ describe('createGetAllHandler', () => {
 
             handler(createCall({ size: 0 }), callback);
 
-            expect(callback).toHaveBeenCalledWith({ code: grpc.status.INVALID_ARGUMENT });
+            expect(callback).toHaveBeenCalledWith({
+                code: grpc.status.INVALID_ARGUMENT,
+                message: 'page and size must be greater than or equal to 1.',
+            });
         });
 
         it('returns OUT_OF_RANGE when page exceeds total pages', () => {
@@ -78,7 +93,10 @@ describe('createGetAllHandler', () => {
 
             handler(createCall({ page: 999, size: 10 }), callback);
 
-            expect(callback).toHaveBeenCalledWith({ code: grpc.status.OUT_OF_RANGE });
+            expect(callback).toHaveBeenCalledWith({
+                code: grpc.status.OUT_OF_RANGE,
+                message: 'Requested page 999 exceeds available pages (4).',
+            });
         });
     });
 
@@ -106,24 +124,24 @@ describe('createGetAllHandler', () => {
             expect(response.data).toHaveLength(10);
         });
 
-        it('sets links.next to the next page number when more pages exist', () => {
+        it('sets links.next_page to the next page number when more pages exist', () => {
             const handler = createGetAllHandler(world);
 
             handler(createCall({ page: 1, size: 10 }), callback);
 
             const [, response] = callback.mock.calls[0];
 
-            expect(response.links.next).toBe('2');
+            expect(response.links.next_page).toBe('2');
         });
 
-        it('sets links.next to empty string on the last page', () => {
+        it('sets links.next_page to empty string on the last page', () => {
             const handler = createGetAllHandler(world);
 
             handler(createCall({ page: 4, size: 10 }), callback);
 
             const [, response] = callback.mock.calls[0];
 
-            expect(response.links.next).toBe('');
+            expect(response.links.next_page).toBe('');
         });
 
         it('returns correct page metadata', () => {

--- a/grpc.spec.js
+++ b/grpc.spec.js
@@ -1,0 +1,144 @@
+import {
+    beforeEach, describe, expect, it, vi,
+} from 'vitest';
+import grpc from '@grpc/grpc-js';
+import { createGetAllHandler } from './grpc.js';
+
+vi.mock('./helpers/config.js', () => ({
+    default: {
+        notificationHeaders: { 'x-test-header': 'test-value' },
+    },
+}));
+vi.mock('./helpers/pool.js', () => ({ default: {} }));
+vi.mock('./helpers/world2.js', () => ({ default: vi.fn() }));
+
+const createCall = ({ headerValue = 'test-value', page = null, size = null } = {}) => ({
+    metadata: {
+        get: (key) => (key === 'x-test-header' ? [headerValue] : []),
+    },
+    request: { page, size },
+});
+
+describe('createGetAllHandler', () => {
+    let callback;
+    let world;
+
+    beforeEach(() => {
+        callback = vi.fn();
+        world = { items: Array.from({ length: 33 }, (_, i) => ({ hash: i })) };
+    });
+
+    describe('authentication', () => {
+        it('returns UNAUTHENTICATED when header value is wrong', () => {
+            const handler = createGetAllHandler(world);
+
+            handler(createCall({ headerValue: 'wrong' }), callback);
+
+            expect(callback).toHaveBeenCalledWith({ code: grpc.status.UNAUTHENTICATED });
+        });
+    });
+
+    describe('world not ready', () => {
+        it('returns UNAVAILABLE when items is undefined', () => {
+            const handler = createGetAllHandler({ items: undefined });
+
+            handler(createCall(), callback);
+
+            expect(callback).toHaveBeenCalledWith({ code: grpc.status.UNAVAILABLE });
+        });
+
+        it('returns UNAVAILABLE when items is empty', () => {
+            const handler = createGetAllHandler({ items: [] });
+
+            handler(createCall(), callback);
+
+            expect(callback).toHaveBeenCalledWith({ code: grpc.status.UNAVAILABLE });
+        });
+    });
+
+    describe('parameter validation', () => {
+        it('returns INVALID_ARGUMENT when page is 0', () => {
+            const handler = createGetAllHandler(world);
+
+            handler(createCall({ page: 0 }), callback);
+
+            expect(callback).toHaveBeenCalledWith({ code: grpc.status.INVALID_ARGUMENT });
+        });
+
+        it('returns INVALID_ARGUMENT when size is 0', () => {
+            const handler = createGetAllHandler(world);
+
+            handler(createCall({ size: 0 }), callback);
+
+            expect(callback).toHaveBeenCalledWith({ code: grpc.status.INVALID_ARGUMENT });
+        });
+
+        it('returns OUT_OF_RANGE when page exceeds total pages', () => {
+            const handler = createGetAllHandler(world);
+
+            handler(createCall({ page: 999, size: 10 }), callback);
+
+            expect(callback).toHaveBeenCalledWith({ code: grpc.status.OUT_OF_RANGE });
+        });
+    });
+
+    describe('pagination', () => {
+        it('defaults to page 1, size 11 when request fields are null', () => {
+            const handler = createGetAllHandler(world);
+
+            handler(createCall(), callback);
+
+            const [, response] = callback.mock.calls[0];
+
+            expect(response.page.number).toBe(1);
+            expect(response.page.size).toBe(11);
+            expect(response.data).toHaveLength(11);
+        });
+
+        it('returns the correct slice for a given page', () => {
+            const handler = createGetAllHandler(world);
+
+            handler(createCall({ page: 2, size: 10 }), callback);
+
+            const [, response] = callback.mock.calls[0];
+
+            expect(response.data[0].hash).toBe(10);
+            expect(response.data).toHaveLength(10);
+        });
+
+        it('sets links.next to the next page number when more pages exist', () => {
+            const handler = createGetAllHandler(world);
+
+            handler(createCall({ page: 1, size: 10 }), callback);
+
+            const [, response] = callback.mock.calls[0];
+
+            expect(response.links.next).toBe('2');
+        });
+
+        it('sets links.next to empty string on the last page', () => {
+            const handler = createGetAllHandler(world);
+
+            handler(createCall({ page: 4, size: 10 }), callback);
+
+            const [, response] = callback.mock.calls[0];
+
+            expect(response.links.next).toBe('');
+        });
+
+        it('returns correct page metadata', () => {
+            const handler = createGetAllHandler(world);
+
+            handler(createCall({ page: 2, size: 10 }), callback);
+
+            const [, response] = callback.mock.calls[0];
+
+            expect(response.page).toEqual({
+                size: 10,
+                total: 33,
+                pages: 4,
+                number: 2,
+            });
+        });
+    });
+});

--- a/items.proto
+++ b/items.proto
@@ -5,8 +5,10 @@ service ItemService {
 }
 
 message PageRequest {
-    int32 page = 1;
-    int32 size = 2;
+    // 1-based page number; must be >= 1.
+    uint32 page = 1;
+    // Page size; must be >= 1 and <= 100.
+    uint32 size = 2;
 }
 
 message Item {

--- a/items.proto
+++ b/items.proto
@@ -1,10 +1,13 @@
 syntax = "proto3";
 
 service ItemService {
-    rpc GetAll (Empty) returns (ItemList) {}
+    rpc GetAll (PageRequest) returns (ItemPage) {}
 }
 
-message Empty {}
+message PageRequest {
+    int32 page = 1;
+    int32 size = 2;
+}
 
 message Item {
     message DisplayProperties {
@@ -37,6 +40,19 @@ message Item {
     int32 hash = 18;
 }
 
-message ItemList {
-    repeated Item items = 1;
+message Links {
+    string next = 1;
+}
+
+message PageInfo {
+    int32 size = 1;
+    int32 total = 2;
+    int32 pages = 3;
+    int32 number = 4;
+}
+
+message ItemPage {
+    repeated Item data = 1;
+    Links links = 2;
+    PageInfo page = 3;
 }

--- a/items.proto
+++ b/items.proto
@@ -47,10 +47,10 @@ message Links {
 }
 
 message PageInfo {
-    int32 size = 1;
-    int32 total = 2;
-    int32 pages = 3;
-    int32 number = 4;
+    uint32 size = 1;
+    uint64 total = 2;
+    uint32 pages = 3;
+    uint32 number = 4;
 }
 
 message ItemPage {

--- a/items.proto
+++ b/items.proto
@@ -43,7 +43,8 @@ message Item {
 }
 
 message Links {
-    string next = 1;
+    // 1-based next page number as a string; empty when there is no next page.
+    string next_page = 1;
 }
 
 message PageInfo {

--- a/items.proto
+++ b/items.proto
@@ -7,7 +7,7 @@ service ItemService {
 message PageRequest {
     // 1-based page number; must be >= 1.
     uint32 page = 1;
-    // Page size; must be >= 1 and <= 100.
+    // Page size; must be >= 1.
     uint32 size = 2;
 }
 

--- a/items.proto
+++ b/items.proto
@@ -5,10 +5,10 @@ service ItemService {
 }
 
 message PageRequest {
-    // 1-based page number; must be >= 1.
-    uint32 page = 1;
-    // Page size; must be >= 1.
-    uint32 size = 2;
+    // 1-based page number; must be >= 1. Omit to use the default (page 1).
+    optional uint32 page = 1;
+    // Page size; must be >= 1. Omit to use the default (size 11).
+    optional uint32 size = 2;
 }
 
 message Item {


### PR DESCRIPTION
## Summary

- Replaces the unbounded `GetAll` response (which caused `ResourceExhausted` errors at >4 MB) with paginated results
- `PageRequest` message accepts `optional uint32 page` (default 1) and `optional uint32 size` (default 11) params
- Response structure mirrors the HTTP `/destiny2/inventory` endpoint: `data`, `links.next_page`, and `page` metadata
- `links.next_page` returns the next page number as a string, or empty string on the last page
- Error responses include descriptive `message` strings for easier debugging

## Test plan

- [ ] `grpcurl -d '{"page": 1, "size": 25}' localhost:1102 ItemService/GetAll` returns first 25 items with correct `page` metadata
- [ ] `links.next_page` is populated when more pages exist, empty on the last page
- [ ] `grpcurl -d '{}'` uses defaults (page=1, size=11)
- [ ] `grpcurl -d '{"page": 0}'` returns `INVALID_ARGUMENT`
- [ ] `grpcurl -d '{"page": 9999}'` returns `OUT_OF_RANGE`
- [ ] Unauthenticated requests still return `UNAUTHENTICATED` status

🤖 Generated with [Claude Code](https://claude.com/claude-code)