### PR TITLE
Handle inventory stream backpressure

### DIFF
--- a/destiny2/destiny2.routes.js
+++ b/destiny2/destiny2.routes.js
@@ -21,14 +21,14 @@ async function writeChunk(res, chunk) {
         return true;
     }
 
-    await new Promise(resolve => {
+    const drained = await new Promise(resolve => {
         const handleDrain = () => {
             cleanup();
-            resolve();
+            resolve(true);
         };
         const handleClose = () => {
             cleanup();
-            resolve();
+            resolve(false);
         };
         const cleanup = () => {
             res.off('drain', handleDrain);
@@ -39,7 +39,7 @@ async function writeChunk(res, chunk) {
         res.on('close', handleClose);
     });
 
-    return !res.writableEnded && !res.destroyed;
+    return drained && !res.writableEnded && !res.destroyed;
 }
 
 /**

--- a/destiny2/destiny2.routes.js
+++ b/destiny2/destiny2.routes.js
@@ -37,6 +37,7 @@ async function writeChunk(res, chunk) {
     const drained = await new Promise(resolve => {
         const socket = res.socket;
         const previousSocketTimeout = socket?.timeout;
+        let cleaned = false;
         let drainEmitter;
         let timeout;
         const handleDrain = () => {
@@ -62,6 +63,8 @@ async function writeChunk(res, chunk) {
             resolveWith(inventoryStreamWriteResult.timedOut);
         };
         const cleanup = () => {
+            if (cleaned) return;
+            cleaned = true;
             drainEmitter.off('drain', handleDrain);
             res.off('close', handleClose);
 

--- a/destiny2/destiny2.routes.js
+++ b/destiny2/destiny2.routes.js
@@ -2,7 +2,6 @@
  * Created by chris on 9/25/15.
  */
 import { StatusCodes } from 'http-status-codes';
-import { once } from 'node:events';
 import cors from 'cors';
 import { Router } from 'express';
 import AuthenticationMiddleware from '../authentication/authentication.middleware.js';
@@ -22,7 +21,23 @@ async function writeChunk(res, chunk) {
         return true;
     }
 
-    await Promise.race([once(res, 'drain'), once(res, 'close')]);
+    await new Promise(resolve => {
+        const handleDrain = () => {
+            cleanup();
+            resolve();
+        };
+        const handleClose = () => {
+            cleanup();
+            resolve();
+        };
+        const cleanup = () => {
+            res.off('drain', handleDrain);
+            res.off('close', handleClose);
+        };
+
+        res.on('drain', handleDrain);
+        res.on('close', handleClose);
+    });
 
     return !res.writableEnded && !res.destroyed;
 }

--- a/destiny2/destiny2.routes.js
+++ b/destiny2/destiny2.routes.js
@@ -45,10 +45,15 @@ async function writeChunk(res, chunk) {
                     : inventoryStreamWriteResult.ok,
             );
         };
+        let timedOut = false;
         const handleClose = () => {
-            resolveWith(inventoryStreamWriteResult.closed);
+            resolveWith(
+                timedOut ? inventoryStreamWriteResult.timedOut : inventoryStreamWriteResult.closed,
+            );
         };
         const handleTimeout = () => {
+            timedOut = true;
+
             if (typeof res.destroy === 'function' && !res.destroyed) {
                 res.destroy();
             }

--- a/destiny2/destiny2.routes.js
+++ b/destiny2/destiny2.routes.js
@@ -12,6 +12,8 @@ import toTemporalInstant from '../helpers/to-temporal-instant.js';
 
 import configuration from '../helpers/config.js';
 
+const inventoryStreamBackpressureTimeoutMs = 30 * 1000;
+
 async function writeChunk(res, chunk) {
     if (res.writableEnded || res.destroyed) {
         return false;
@@ -22,6 +24,13 @@ async function writeChunk(res, chunk) {
     }
 
     const drained = await new Promise(resolve => {
+        const timeout = setTimeout(() => {
+            cleanup();
+            if (typeof res.destroy === 'function' && !res.destroyed) {
+                res.destroy(new Error('Inventory stream backpressure timeout'));
+            }
+            resolve(false);
+        }, inventoryStreamBackpressureTimeoutMs);
         const handleDrain = () => {
             cleanup();
             resolve(true);
@@ -31,10 +40,12 @@ async function writeChunk(res, chunk) {
             resolve(false);
         };
         const cleanup = () => {
+            clearTimeout(timeout);
             res.off('drain', handleDrain);
             res.off('close', handleClose);
         };
 
+        timeout.unref?.();
         res.on('drain', handleDrain);
         res.on('close', handleClose);
     });

--- a/destiny2/destiny2.routes.js
+++ b/destiny2/destiny2.routes.js
@@ -12,45 +12,77 @@ import toTemporalInstant from '../helpers/to-temporal-instant.js';
 
 import configuration from '../helpers/config.js';
 
-const inventoryStreamBackpressureTimeoutMs = 30 * 1000;
+const inventoryStreamBackpressureIdleTimeoutMs = 30 * 1000;
+const inventoryStreamWriteResult = Object.freeze({
+    closed: 'closed',
+    ok: 'ok',
+    timedOut: 'timed_out',
+});
+
+function getInventoryStreamBackpressureIdleTimeoutMs() {
+    const value = Number.parseInt(process.env.INVENTORY_STREAM_BACKPRESSURE_TIMEOUT_MS, 10);
+
+    return Number.isFinite(value) && value > 0 ? value : inventoryStreamBackpressureIdleTimeoutMs;
+}
 
 async function writeChunk(res, chunk) {
     if (res.writableEnded || res.destroyed) {
-        return false;
+        return inventoryStreamWriteResult.closed;
     }
 
     if (res.write(chunk)) {
-        return true;
+        return inventoryStreamWriteResult.ok;
     }
 
     const drained = await new Promise(resolve => {
-        const timeout = setTimeout(() => {
-            cleanup();
+        const socket = res.socket;
+        let timeout;
+        const handleDrain = () => {
+            resolveWith(
+                res.writableEnded || res.destroyed
+                    ? inventoryStreamWriteResult.closed
+                    : inventoryStreamWriteResult.ok,
+            );
+        };
+        const handleClose = () => {
+            resolveWith(inventoryStreamWriteResult.closed);
+        };
+        const handleTimeout = () => {
             if (typeof res.destroy === 'function' && !res.destroyed) {
                 res.destroy();
             }
-            resolve(false);
-        }, inventoryStreamBackpressureTimeoutMs);
-        const handleDrain = () => {
-            cleanup();
-            resolve(true);
-        };
-        const handleClose = () => {
-            cleanup();
-            resolve(false);
+
+            resolveWith(inventoryStreamWriteResult.timedOut);
         };
         const cleanup = () => {
-            clearTimeout(timeout);
             res.off('drain', handleDrain);
             res.off('close', handleClose);
+
+            if (socket?.setTimeout) {
+                socket.off('timeout', handleTimeout);
+                socket.setTimeout(0);
+            } else if (timeout) {
+                clearTimeout(timeout);
+            }
+        };
+        const resolveWith = result => {
+            cleanup();
+            resolve(result);
         };
 
-        timeout.unref?.();
         res.on('drain', handleDrain);
         res.on('close', handleClose);
+
+        if (socket?.setTimeout) {
+            socket.setTimeout(getInventoryStreamBackpressureIdleTimeoutMs());
+            socket.on('timeout', handleTimeout);
+        } else {
+            timeout = setTimeout(handleTimeout, getInventoryStreamBackpressureIdleTimeoutMs());
+            timeout.unref?.();
+        }
     });
 
-    return drained && !res.writableEnded && !res.destroyed;
+    return drained;
 }
 
 /**
@@ -165,12 +197,19 @@ const routes = ({ authenticationController, destiny2Controller }) => {
                     return res.end();
                 }
 
-                const canContinue = await writeChunk(
+                const writeResult = await writeChunk(
                     res,
                     first ? `[${JSON.stringify(item)}` : `,${JSON.stringify(item)}`,
                 );
 
-                if (!canContinue) {
+                if (writeResult !== inventoryStreamWriteResult.ok) {
+                    if (writeResult === inventoryStreamWriteResult.timedOut) {
+                        log.warn(
+                            `${req.method} ${req.url} inventory stream timed out while waiting for drain at item ${index} of ${items.length}`,
+                        );
+                        return;
+                    }
+
                     log.info(
                         `${req.method} ${req.url} request closed while streaming item ${index} of ${items.length}`,
                     );
@@ -182,7 +221,16 @@ const routes = ({ authenticationController, destiny2Controller }) => {
                 await new Promise(resolve => setImmediate(resolve));
             }
 
-            if (!(await writeChunk(res, ']'))) {
+            const writeResult = await writeChunk(res, ']');
+
+            if (writeResult !== inventoryStreamWriteResult.ok) {
+                if (writeResult === inventoryStreamWriteResult.timedOut) {
+                    log.warn(
+                        `${req.method} ${req.url} inventory stream timed out before completion`,
+                    );
+                    return;
+                }
+
                 log.info(`${req.method} ${req.url} request closed before inventory completed`);
                 return res.end();
             }

--- a/destiny2/destiny2.routes.js
+++ b/destiny2/destiny2.routes.js
@@ -37,6 +37,7 @@ async function writeChunk(res, chunk) {
     const drained = await new Promise(resolve => {
         const socket = res.socket;
         const previousSocketTimeout = socket?.timeout;
+        let drainEmitter;
         let timeout;
         const handleDrain = () => {
             resolveWith(
@@ -61,7 +62,7 @@ async function writeChunk(res, chunk) {
             resolveWith(inventoryStreamWriteResult.timedOut);
         };
         const cleanup = () => {
-            res.off('drain', handleDrain);
+            drainEmitter.off('drain', handleDrain);
             res.off('close', handleClose);
 
             if (socket?.setTimeout) {
@@ -76,7 +77,7 @@ async function writeChunk(res, chunk) {
             resolve(result);
         };
 
-        res.on('drain', handleDrain);
+        drainEmitter = res.on('drain', handleDrain);
         res.on('close', handleClose);
 
         if (socket?.setTimeout) {

--- a/destiny2/destiny2.routes.js
+++ b/destiny2/destiny2.routes.js
@@ -36,6 +36,7 @@ async function writeChunk(res, chunk) {
 
     const drained = await new Promise(resolve => {
         const socket = res.socket;
+        const previousSocketTimeout = socket?.timeout;
         let timeout;
         const handleDrain = () => {
             resolveWith(
@@ -60,7 +61,7 @@ async function writeChunk(res, chunk) {
 
             if (socket?.setTimeout) {
                 socket.off('timeout', handleTimeout);
-                socket.setTimeout(0);
+                socket.setTimeout(previousSocketTimeout ?? 0);
             } else if (timeout) {
                 clearTimeout(timeout);
             }

--- a/destiny2/destiny2.routes.js
+++ b/destiny2/destiny2.routes.js
@@ -27,7 +27,7 @@ async function writeChunk(res, chunk) {
         const timeout = setTimeout(() => {
             cleanup();
             if (typeof res.destroy === 'function' && !res.destroyed) {
-                res.destroy(new Error('Inventory stream backpressure timeout'));
+                res.destroy();
             }
             resolve(false);
         }, inventoryStreamBackpressureTimeoutMs);

--- a/destiny2/destiny2.routes.js
+++ b/destiny2/destiny2.routes.js
@@ -2,6 +2,7 @@
  * Created by chris on 9/25/15.
  */
 import { StatusCodes } from 'http-status-codes';
+import { once } from 'node:events';
 import cors from 'cors';
 import { Router } from 'express';
 import AuthenticationMiddleware from '../authentication/authentication.middleware.js';
@@ -11,6 +12,20 @@ import log from '../helpers/log.js';
 import toTemporalInstant from '../helpers/to-temporal-instant.js';
 
 import configuration from '../helpers/config.js';
+
+async function writeChunk(res, chunk) {
+    if (res.writableEnded || res.destroyed) {
+        return false;
+    }
+
+    if (res.write(chunk)) {
+        return true;
+    }
+
+    await Promise.race([once(res, 'drain'), once(res, 'close')]);
+
+    return !res.writableEnded && !res.destroyed;
+}
 
 /**
  * @openapi
@@ -124,13 +139,28 @@ const routes = ({ authenticationController, destiny2Controller }) => {
                     return res.end();
                 }
 
-                res.write(first ? `[${JSON.stringify(item)}` : `,${JSON.stringify(item)}`);
+                const canContinue = await writeChunk(
+                    res,
+                    first ? `[${JSON.stringify(item)}` : `,${JSON.stringify(item)}`,
+                );
+
+                if (!canContinue) {
+                    log.info(
+                        `${req.method} ${req.url} request closed while streaming item ${index} of ${items.length}`,
+                    );
+                    return res.end();
+                }
                 first = false;
 
                 // Introduce a delay to allow the event loop to process the 'close' event
                 await new Promise(resolve => setImmediate(resolve));
             }
-            res.write(']');
+
+            if (!(await writeChunk(res, ']'))) {
+                log.info(`${req.method} ${req.url} request closed before inventory completed`);
+                return res.end();
+            }
+
             res.end();
         } else {
             if (Number.isNaN(page)) page = 1;

--- a/destiny2/destiny2.routes.js
+++ b/destiny2/destiny2.routes.js
@@ -86,6 +86,19 @@ async function writeChunk(res, chunk) {
     return drained;
 }
 
+function handleWriteResult(req, res, writeResult, context) {
+    if (writeResult === inventoryStreamWriteResult.ok) return false;
+
+    if (writeResult === inventoryStreamWriteResult.timedOut) {
+        log.warn(`${req.method} ${req.url} inventory stream timed out ${context}`);
+    } else {
+        log.info(`${req.method} ${req.url} request closed ${context}`);
+        if (!res.writableEnded && !res.destroyed) res.end();
+    }
+
+    return true;
+}
+
 /**
  * @openapi
  *  components:
@@ -203,19 +216,15 @@ const routes = ({ authenticationController, destiny2Controller }) => {
                     first ? `[${JSON.stringify(item)}` : `,${JSON.stringify(item)}`,
                 );
 
-                if (writeResult !== inventoryStreamWriteResult.ok) {
-                    if (writeResult === inventoryStreamWriteResult.timedOut) {
-                        log.warn(
-                            `${req.method} ${req.url} inventory stream timed out while waiting for drain at item ${index} of ${items.length}`,
-                        );
-                        return;
-                    }
-
-                    log.info(
-                        `${req.method} ${req.url} request closed while streaming item ${index} of ${items.length}`,
-                    );
-                    return res.end();
-                }
+                if (
+                    handleWriteResult(
+                        req,
+                        res,
+                        writeResult,
+                        `while streaming item ${index} of ${items.length}`,
+                    )
+                )
+                    return;
                 first = false;
 
                 // Introduce a delay to allow the event loop to process the 'close' event
@@ -224,17 +233,7 @@ const routes = ({ authenticationController, destiny2Controller }) => {
 
             const writeResult = await writeChunk(res, ']');
 
-            if (writeResult !== inventoryStreamWriteResult.ok) {
-                if (writeResult === inventoryStreamWriteResult.timedOut) {
-                    log.warn(
-                        `${req.method} ${req.url} inventory stream timed out before completion`,
-                    );
-                    return;
-                }
-
-                log.info(`${req.method} ${req.url} request closed before inventory completed`);
-                return res.end();
-            }
+            if (handleWriteResult(req, res, writeResult, 'before inventory completed')) return;
 
             res.end();
         } else {

--- a/destiny2/destiny2.routes.spec.js
+++ b/destiny2/destiny2.routes.spec.js
@@ -165,10 +165,6 @@ describe('Destiny2Router', () => {
                     originalWrite(chunk);
 
                     if (writeCalls === 1) {
-                        setImmediate(() => {
-                            res.emit('drain');
-                        });
-
                         return false;
                     }
 
@@ -187,6 +183,15 @@ describe('Destiny2Router', () => {
                 });
 
                 destiny2Router(req, res, next);
+
+                setImmediate(() => {
+                    try {
+                        expect(res.write).toHaveBeenCalledTimes(1);
+                        res.emit('drain');
+                    } catch (err) {
+                        reject(err);
+                    }
+                });
             }));
     });
 });

--- a/destiny2/destiny2.routes.spec.js
+++ b/destiny2/destiny2.routes.spec.js
@@ -4,9 +4,14 @@ import { StatusCodes } from 'http-status-codes';
 import Chance from 'chance';
 import { createResponse, createRequest } from 'node-mocks-http';
 
+vi.mock('../authorization/authorization.middleware.js', () => ({
+    default: vi.fn((_req, _res, next) => next()),
+}));
+
 import Destiny2Router from './destiny2.routes.js';
 import Destiny2Controller from './destiny2.controller.js';
 import manifest2Response from '../mocks/manifest2Response.json';
+import authorizeUser from '../authorization/authorization.middleware.js';
 
 const { Response: manifest } = manifest2Response;
 const chance = new Chance();
@@ -64,6 +69,7 @@ describe('Destiny2Router', () => {
         res = createResponse({
             eventEmitter: EventEmitter,
         });
+        authorizeUser.mockImplementation((_req, _res, next) => next());
     });
 
     describe('getCharacters', () => {
@@ -136,5 +142,51 @@ describe('Destiny2Router', () => {
                     destiny2Router(req, res, next);
                 }));
         });
+    });
+
+    describe('getInventory', () => {
+        it('should wait for drain when the response stream applies backpressure', () =>
+            new Promise((done, reject) => {
+                const req = createRequest({
+                    method: 'GET',
+                    url: '/inventory',
+                    query: {},
+                });
+                const originalWrite = res.write.bind(res);
+                let writeCalls = 0;
+
+                world.items = [
+                    { hash: 1, displayProperties: { name: 'One' } },
+                    { hash: 2, displayProperties: { name: 'Two' } },
+                ];
+
+                res.write = vi.fn(chunk => {
+                    writeCalls += 1;
+                    originalWrite(chunk);
+
+                    if (writeCalls === 1) {
+                        setImmediate(() => {
+                            res.emit('drain');
+                        });
+
+                        return false;
+                    }
+
+                    return true;
+                });
+
+                res.on('end', () => {
+                    try {
+                        expect(res.statusCode).toEqual(StatusCodes.OK);
+                        expect(res.write).toHaveBeenCalledTimes(3);
+                        expect(JSON.parse(res._getData())).toEqual(world.items);
+                        done();
+                    } catch (err) {
+                        reject(err);
+                    }
+                });
+
+                destiny2Router(req, res, next);
+            }));
     });
 });

--- a/destiny2/destiny2.routes.spec.js
+++ b/destiny2/destiny2.routes.spec.js
@@ -193,5 +193,50 @@ describe('Destiny2Router', () => {
                     }
                 });
             }));
+
+        it('should stop streaming when the response closes while waiting for drain', () =>
+            new Promise((done, reject) => {
+                const req = createRequest({
+                    method: 'GET',
+                    url: '/inventory',
+                    query: {},
+                });
+                const originalWrite = res.write.bind(res);
+                let writeCalls = 0;
+
+                world.items = [
+                    { hash: 1, displayProperties: { name: 'One' } },
+                    { hash: 2, displayProperties: { name: 'Two' } },
+                ];
+
+                res.write = vi.fn(chunk => {
+                    writeCalls += 1;
+                    originalWrite(chunk);
+
+                    return writeCalls > 1;
+                });
+
+                res.on('end', () => {
+                    try {
+                        expect(res.statusCode).toEqual(StatusCodes.OK);
+                        expect(res.write).toHaveBeenCalledTimes(1);
+                        expect(res._getData()).toEqual(`[${JSON.stringify(world.items[0])}`);
+                        done();
+                    } catch (err) {
+                        reject(err);
+                    }
+                });
+
+                destiny2Router(req, res, next);
+
+                setImmediate(() => {
+                    try {
+                        expect(res.write).toHaveBeenCalledTimes(1);
+                        res.emit('close');
+                    } catch (err) {
+                        reject(err);
+                    }
+                });
+            }));
     });
 });

--- a/destiny2/destiny2.routes.spec.js
+++ b/destiny2/destiny2.routes.spec.js
@@ -4,14 +4,10 @@ import { StatusCodes } from 'http-status-codes';
 import Chance from 'chance';
 import { createResponse, createRequest } from 'node-mocks-http';
 
-vi.mock('../authorization/authorization.middleware.js', () => ({
-    default: vi.fn((_req, _res, next) => next()),
-}));
-
 import Destiny2Router from './destiny2.routes.js';
 import Destiny2Controller from './destiny2.controller.js';
 import manifest2Response from '../mocks/manifest2Response.json';
-import authorizeUser from '../authorization/authorization.middleware.js';
+import configuration from '../helpers/config.js';
 
 const { Response: manifest } = manifest2Response;
 const chance = new Chance();
@@ -69,7 +65,6 @@ describe('Destiny2Router', () => {
         res = createResponse({
             eventEmitter: EventEmitter,
         });
-        authorizeUser.mockImplementation((_req, _res, next) => next());
     });
 
     describe('getCharacters', () => {
@@ -145,12 +140,33 @@ describe('Destiny2Router', () => {
     });
 
     describe('getInventory', () => {
+        it('should respond with unauthorized when notification headers are missing', () =>
+            new Promise((done, reject) => {
+                const req = createRequest({
+                    method: 'GET',
+                    url: '/inventory',
+                    query: {},
+                });
+
+                res.on('end', () => {
+                    try {
+                        expect(res.statusCode).toEqual(StatusCodes.UNAUTHORIZED);
+                        done();
+                    } catch (err) {
+                        reject(err);
+                    }
+                });
+
+                destiny2Router(req, res, next);
+            }));
+
         it('should wait for drain when the response stream applies backpressure', () =>
             new Promise((done, reject) => {
                 const req = createRequest({
                     method: 'GET',
                     url: '/inventory',
                     query: {},
+                    headers: configuration.notificationHeaders,
                 });
                 const originalWrite = res.write.bind(res);
                 let writeCalls = 0;
@@ -200,6 +216,7 @@ describe('Destiny2Router', () => {
                     method: 'GET',
                     url: '/inventory',
                     query: {},
+                    headers: configuration.notificationHeaders,
                 });
                 const originalWrite = res.write.bind(res);
                 let writeCalls = 0;
@@ -238,5 +255,48 @@ describe('Destiny2Router', () => {
                     }
                 });
             }));
+
+        it('should stop streaming when backpressure does not drain in time', async () => {
+            vi.useFakeTimers();
+
+            try {
+                const req = createRequest({
+                    method: 'GET',
+                    url: '/inventory',
+                    query: {},
+                    headers: configuration.notificationHeaders,
+                });
+                const originalWrite = res.write.bind(res);
+
+                world.items = [
+                    { hash: 1, displayProperties: { name: 'One' } },
+                    { hash: 2, displayProperties: { name: 'Two' } },
+                ];
+                res.destroy = vi.fn(err => {
+                    res.destroyed = true;
+                    res.emit('close', err);
+                });
+                res.write = vi.fn(chunk => {
+                    originalWrite(chunk);
+
+                    return false;
+                });
+
+                const responseComplete = new Promise((resolve, reject) => {
+                    res.on('end', resolve);
+                    res.on('error', reject);
+                });
+
+                destiny2Router(req, res, next);
+                await vi.advanceTimersByTimeAsync(30 * 1000);
+                await responseComplete;
+
+                expect(res.destroy).toHaveBeenCalledOnce();
+                expect(res.write).toHaveBeenCalledTimes(1);
+                expect(res._getData()).toEqual(`[${JSON.stringify(world.items[0])}`);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
     });
 });

--- a/destiny2/destiny2.routes.spec.js
+++ b/destiny2/destiny2.routes.spec.js
@@ -273,7 +273,9 @@ describe('Destiny2Router', () => {
                     { hash: 1, displayProperties: { name: 'One' } },
                     { hash: 2, displayProperties: { name: 'Two' } },
                 ];
+                socket.timeout = 5000;
                 socket.setTimeout = vi.fn(ms => {
+                    socket.timeout = ms;
                     clearTimeout(socket.timeoutId);
 
                     if (ms > 0) {
@@ -308,7 +310,7 @@ describe('Destiny2Router', () => {
                 expect(res.destroy).toHaveBeenCalledOnce();
                 expect(res.destroy).toHaveBeenCalledWith();
                 expect(socket.setTimeout).toHaveBeenNthCalledWith(1, 30 * 1000);
-                expect(socket.setTimeout).toHaveBeenLastCalledWith(0);
+                expect(socket.setTimeout).toHaveBeenLastCalledWith(5000);
                 expect(res.write).toHaveBeenCalledTimes(1);
                 expect(res._getData()).toEqual(`[${JSON.stringify(world.items[0])}`);
             } finally {

--- a/destiny2/destiny2.routes.spec.js
+++ b/destiny2/destiny2.routes.spec.js
@@ -226,8 +226,6 @@ describe('Destiny2Router', () => {
                     query: {},
                     headers: configuration.notificationHeaders,
                 });
-                const drainEmitter = new EventEmitter();
-                const originalOn = res.on.bind(res);
                 const originalWrite = res.write.bind(res);
                 let writeCalls = 0;
                 const socket = new EventEmitter();
@@ -241,17 +239,6 @@ describe('Destiny2Router', () => {
                     socket.timeout = ms;
                 });
                 res.socket = socket;
-                res.on = vi.fn((event, listener) => {
-                    if (event === 'drain') {
-                        drainEmitter.on(event, listener);
-
-                        return drainEmitter;
-                    }
-
-                    originalOn(event, listener);
-
-                    return res;
-                });
                 res.write = vi.fn(chunk => {
                     writeCalls += 1;
                     originalWrite(chunk);
@@ -266,7 +253,7 @@ describe('Destiny2Router', () => {
                         expect(socket.setTimeout).toHaveBeenCalledTimes(2);
                         expect(socket.setTimeout).toHaveBeenNthCalledWith(1, 30 * 1000);
                         expect(socket.setTimeout).toHaveBeenLastCalledWith(5000);
-                        expect(drainEmitter.listenerCount('drain')).toEqual(0);
+                        expect(res.listenerCount('drain')).toEqual(0);
                         expect(JSON.parse(res._getData())).toEqual(world.items);
                         done();
                     } catch (err) {
@@ -279,9 +266,9 @@ describe('Destiny2Router', () => {
                 setImmediate(() => {
                     try {
                         expect(res.write).toHaveBeenCalledTimes(1);
-                        expect(drainEmitter.listenerCount('drain')).toEqual(1);
+                        expect(res.listenerCount('drain')).toEqual(1);
                         expect(socket.setTimeout).toHaveBeenNthCalledWith(1, 30 * 1000);
-                        drainEmitter.emit('drain');
+                        res.emit('drain');
                     } catch (err) {
                         reject(err);
                     }
@@ -397,6 +384,60 @@ describe('Destiny2Router', () => {
                 expect(res.destroy).toHaveBeenCalledWith();
                 expect(socket.setTimeout).toHaveBeenNthCalledWith(1, 30 * 1000);
                 expect(socket.setTimeout).toHaveBeenLastCalledWith(5000);
+                expect(log.warn).toHaveBeenCalledWith(
+                    expect.stringContaining(
+                        'inventory stream timed out while streaming item 0 of 2',
+                    ),
+                );
+                expect(log.info).not.toHaveBeenCalled();
+                expect(res.end).not.toHaveBeenCalled();
+                expect(res.write).toHaveBeenCalledTimes(1);
+                expect(res._getData()).toEqual(`[${JSON.stringify(world.items[0])}`);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it('should stop streaming when backpressure idle timeout fires and no socket is available', async () => {
+            vi.useFakeTimers();
+
+            try {
+                const req = createRequest({
+                    method: 'GET',
+                    url: '/inventory',
+                    query: {},
+                    headers: configuration.notificationHeaders,
+                });
+                const originalWrite = res.write.bind(res);
+
+                world.items = [
+                    { hash: 1, displayProperties: { name: 'One' } },
+                    { hash: 2, displayProperties: { name: 'Two' } },
+                ];
+                log.warn.mockClear();
+                log.info.mockClear();
+                res.socket = null;
+                res.end = vi.fn(res.end.bind(res));
+                res.destroy = vi.fn(() => {
+                    res.destroyed = true;
+                    res.emit('close');
+                });
+                res.write = vi.fn(chunk => {
+                    originalWrite(chunk);
+
+                    return false;
+                });
+
+                const responseComplete = new Promise((resolve, reject) => {
+                    res.on('close', resolve);
+                    res.on('error', reject);
+                });
+
+                destiny2Router(req, res, next);
+                await vi.advanceTimersByTimeAsync(30 * 1000);
+                await responseComplete;
+
+                expect(res.destroy).toHaveBeenCalledOnce();
                 expect(log.warn).toHaveBeenCalledWith(
                     expect.stringContaining(
                         'inventory stream timed out while streaming item 0 of 2',

--- a/destiny2/destiny2.routes.spec.js
+++ b/destiny2/destiny2.routes.spec.js
@@ -267,11 +267,22 @@ describe('Destiny2Router', () => {
                     headers: configuration.notificationHeaders,
                 });
                 const originalWrite = res.write.bind(res);
+                const socket = new EventEmitter();
 
                 world.items = [
                     { hash: 1, displayProperties: { name: 'One' } },
                     { hash: 2, displayProperties: { name: 'Two' } },
                 ];
+                socket.setTimeout = vi.fn(ms => {
+                    clearTimeout(socket.timeoutId);
+
+                    if (ms > 0) {
+                        socket.timeoutId = setTimeout(() => {
+                            socket.emit('timeout');
+                        }, ms);
+                    }
+                });
+                res.socket = socket;
                 res.destroy = vi.fn(err => {
                     if (err) {
                         res.emit('error', err);
@@ -286,7 +297,7 @@ describe('Destiny2Router', () => {
                 });
 
                 const responseComplete = new Promise((resolve, reject) => {
-                    res.on('end', resolve);
+                    res.on('close', resolve);
                     res.on('error', reject);
                 });
 
@@ -296,6 +307,8 @@ describe('Destiny2Router', () => {
 
                 expect(res.destroy).toHaveBeenCalledOnce();
                 expect(res.destroy).toHaveBeenCalledWith();
+                expect(socket.setTimeout).toHaveBeenNthCalledWith(1, 30 * 1000);
+                expect(socket.setTimeout).toHaveBeenLastCalledWith(0);
                 expect(res.write).toHaveBeenCalledTimes(1);
                 expect(res._getData()).toEqual(`[${JSON.stringify(world.items[0])}`);
             } finally {

--- a/destiny2/destiny2.routes.spec.js
+++ b/destiny2/destiny2.routes.spec.js
@@ -273,8 +273,11 @@ describe('Destiny2Router', () => {
                     { hash: 2, displayProperties: { name: 'Two' } },
                 ];
                 res.destroy = vi.fn(err => {
+                    if (err) {
+                        res.emit('error', err);
+                    }
                     res.destroyed = true;
-                    res.emit('close', err);
+                    res.emit('close');
                 });
                 res.write = vi.fn(chunk => {
                     originalWrite(chunk);
@@ -292,6 +295,7 @@ describe('Destiny2Router', () => {
                 await responseComplete;
 
                 expect(res.destroy).toHaveBeenCalledOnce();
+                expect(res.destroy).toHaveBeenCalledWith();
                 expect(res.write).toHaveBeenCalledTimes(1);
                 expect(res._getData()).toEqual(`[${JSON.stringify(world.items[0])}`);
             } finally {

--- a/destiny2/destiny2.routes.spec.js
+++ b/destiny2/destiny2.routes.spec.js
@@ -8,6 +8,14 @@ import Destiny2Router from './destiny2.routes.js';
 import Destiny2Controller from './destiny2.controller.js';
 import manifest2Response from '../mocks/manifest2Response.json';
 import configuration from '../helpers/config.js';
+import log from '../helpers/log.js';
+
+vi.mock('../helpers/log.js', () => ({
+    default: {
+        info: vi.fn(),
+        warn: vi.fn(),
+    },
+}));
 
 const { Response: manifest } = manifest2Response;
 const chance = new Chance();
@@ -210,6 +218,76 @@ describe('Destiny2Router', () => {
                 });
             }));
 
+        it('should restore the previous socket timeout when drain resumes streaming', () =>
+            new Promise((done, reject) => {
+                const req = createRequest({
+                    method: 'GET',
+                    url: '/inventory',
+                    query: {},
+                    headers: configuration.notificationHeaders,
+                });
+                const drainEmitter = new EventEmitter();
+                const originalOn = res.on.bind(res);
+                const originalWrite = res.write.bind(res);
+                let writeCalls = 0;
+                const socket = new EventEmitter();
+
+                world.items = [
+                    { hash: 1, displayProperties: { name: 'One' } },
+                    { hash: 2, displayProperties: { name: 'Two' } },
+                ];
+                socket.timeout = 5000;
+                socket.setTimeout = vi.fn(ms => {
+                    socket.timeout = ms;
+                });
+                res.socket = socket;
+                res.on = vi.fn((event, listener) => {
+                    if (event === 'drain') {
+                        drainEmitter.on(event, listener);
+
+                        return drainEmitter;
+                    }
+
+                    originalOn(event, listener);
+
+                    return res;
+                });
+                res.write = vi.fn(chunk => {
+                    writeCalls += 1;
+                    originalWrite(chunk);
+
+                    return writeCalls > 1;
+                });
+
+                res.on('end', () => {
+                    try {
+                        expect(res.statusCode).toEqual(StatusCodes.OK);
+                        expect(res.write).toHaveBeenCalledTimes(3);
+                        expect(socket.setTimeout).toHaveBeenCalledTimes(2);
+                        expect(socket.setTimeout).toHaveBeenNthCalledWith(1, 30 * 1000);
+                        expect(socket.setTimeout).toHaveBeenLastCalledWith(5000);
+                        expect(drainEmitter.listenerCount('drain')).toEqual(0);
+                        expect(JSON.parse(res._getData())).toEqual(world.items);
+                        done();
+                    } catch (err) {
+                        reject(err);
+                    }
+                });
+
+                destiny2Router(req, res, next);
+
+                setImmediate(() => {
+                    try {
+                        expect(res.write).toHaveBeenCalledTimes(1);
+                        expect(drainEmitter.listenerCount('drain')).toEqual(1);
+                        expect(socket.setTimeout).toHaveBeenNthCalledWith(1, 30 * 1000);
+                        drainEmitter.emit('drain');
+                    } catch (err) {
+                        reject(err);
+                    }
+                });
+            }));
+
         it('should stop streaming when the response closes while waiting for drain', () =>
             new Promise((done, reject) => {
                 const req = createRequest({
@@ -226,22 +304,12 @@ describe('Destiny2Router', () => {
                     { hash: 2, displayProperties: { name: 'Two' } },
                 ];
 
+                res.end = vi.fn(res.end.bind(res));
                 res.write = vi.fn(chunk => {
                     writeCalls += 1;
                     originalWrite(chunk);
 
                     return writeCalls > 1;
-                });
-
-                res.on('end', () => {
-                    try {
-                        expect(res.statusCode).toEqual(StatusCodes.OK);
-                        expect(res.write).toHaveBeenCalledTimes(1);
-                        expect(res._getData()).toEqual(`[${JSON.stringify(world.items[0])}`);
-                        done();
-                    } catch (err) {
-                        reject(err);
-                    }
                 });
 
                 destiny2Router(req, res, next);
@@ -253,7 +321,21 @@ describe('Destiny2Router', () => {
                         res.emit('close');
                     } catch (err) {
                         reject(err);
+                        return;
                     }
+
+                    // Allow the async route handler to process the close and return
+                    setImmediate(() => {
+                        try {
+                            expect(res.statusCode).toEqual(StatusCodes.OK);
+                            expect(res.write).toHaveBeenCalledTimes(1);
+                            expect(res.end).not.toHaveBeenCalled();
+                            expect(res._getData()).toEqual(`[${JSON.stringify(world.items[0])}`);
+                            done();
+                        } catch (err) {
+                            reject(err);
+                        }
+                    });
                 });
             }));
 
@@ -274,6 +356,8 @@ describe('Destiny2Router', () => {
                     { hash: 1, displayProperties: { name: 'One' } },
                     { hash: 2, displayProperties: { name: 'Two' } },
                 ];
+                log.warn.mockClear();
+                log.info.mockClear();
                 socket.timeout = 5000;
                 socket.setTimeout = vi.fn(ms => {
                     socket.timeout = ms;
@@ -286,6 +370,7 @@ describe('Destiny2Router', () => {
                     }
                 });
                 res.socket = socket;
+                res.end = vi.fn(res.end.bind(res));
                 res.destroy = vi.fn(err => {
                     if (err) {
                         res.emit('error', err);
@@ -312,6 +397,13 @@ describe('Destiny2Router', () => {
                 expect(res.destroy).toHaveBeenCalledWith();
                 expect(socket.setTimeout).toHaveBeenNthCalledWith(1, 30 * 1000);
                 expect(socket.setTimeout).toHaveBeenLastCalledWith(5000);
+                expect(log.warn).toHaveBeenCalledWith(
+                    expect.stringContaining(
+                        'inventory stream timed out while streaming item 0 of 2',
+                    ),
+                );
+                expect(log.info).not.toHaveBeenCalled();
+                expect(res.end).not.toHaveBeenCalled();
                 expect(res.write).toHaveBeenCalledTimes(1);
                 expect(res._getData()).toEqual(`[${JSON.stringify(world.items[0])}`);
             } finally {

--- a/destiny2/destiny2.routes.spec.js
+++ b/destiny2/destiny2.routes.spec.js
@@ -249,6 +249,7 @@ describe('Destiny2Router', () => {
                 setImmediate(() => {
                     try {
                         expect(res.write).toHaveBeenCalledTimes(1);
+                        res.destroyed = true;
                         res.emit('close');
                     } catch (err) {
                         reject(err);

--- a/destiny2/destiny2.routes.test.js
+++ b/destiny2/destiny2.routes.test.js
@@ -4,6 +4,7 @@ import nock from 'nock';
 import { StatusCodes } from 'http-status-codes';
 import { Readable } from 'node:stream';
 import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
+import Destiny2Controller from './destiny2.controller.js';
 import { startServer, stopServer } from '../server.js';
 import configuration from '../helpers/config.js';
 
@@ -177,8 +178,9 @@ describe('/destiny2', () => {
 
                 test('should close a stalled inventory stream after the backpressure idle timeout', async () => {
                     const originalTimeout = process.env.INVENTORY_STREAM_BACKPRESSURE_TIMEOUT_MS;
+                    const closeGuardMs = 6000;
 
-                    process.env.INVENTORY_STREAM_BACKPRESSURE_TIMEOUT_MS = '1000';
+                    process.env.INVENTORY_STREAM_BACKPRESSURE_TIMEOUT_MS = '100';
 
                     try {
                         const readinessResponse = await get('/destiny2/inventory?page=1&size=1', {
@@ -186,6 +188,7 @@ describe('/destiny2', () => {
                         });
 
                         expect(readinessResponse.status).toEqual(StatusCodes.OK);
+                        await readinessResponse.arrayBuffer();
 
                         await new Promise((resolve, reject) => {
                             const request = http.get(
@@ -207,7 +210,7 @@ describe('/destiny2', () => {
                                                 'Expected the stalled inventory stream to close before timing out',
                                             ),
                                         );
-                                    }, 2000);
+                                    }, closeGuardMs);
 
                                     response.once('end', () => {
                                         clearTimeout(timeout);
@@ -249,7 +252,101 @@ describe('/destiny2', () => {
                             process.env.INVENTORY_STREAM_BACKPRESSURE_TIMEOUT_MS = originalTimeout;
                         }
                     }
-                });
+                }, 9000);
+
+                test('should not leak drain listeners while streaming a gzip-compressed inventory response', async () => {
+                    const originalGetInventory = Destiny2Controller.prototype.getInventory;
+                    const warnings = [];
+                    const handleWarning = warning => {
+                        warnings.push(warning);
+                    };
+
+                    Destiny2Controller.prototype.getInventory = async function () {
+                        const items = await originalGetInventory.call(this);
+
+                        if (!items?.length) {
+                            return items;
+                        }
+
+                        return items.map((item, index) => ({
+                            ...item,
+                            // Inflate the streamed payload so gzip backpressure cycles happen within the test window.
+                            flavorText: [
+                                item.flavorText ?? '',
+                                ...(index < 500
+                                    ? Array.from(
+                                          { length: 256 },
+                                          (_, paddingIndex) =>
+                                              `${item.hash}-${index}-${paddingIndex.toString(36)}`,
+                                      )
+                                    : []),
+                            ].join('|'),
+                        }));
+                    };
+                    process.on('warning', handleWarning);
+
+                    try {
+                        const readinessResponse = await get('/destiny2/inventory?page=1&size=1', {
+                            headers: configuration.notificationHeaders,
+                        });
+
+                        expect(readinessResponse.status).toEqual(StatusCodes.OK);
+                        await readinessResponse.arrayBuffer();
+
+                        await new Promise((resolve, reject) => {
+                            const request = http.get(
+                                `${baseUrl}/destiny2/inventory`,
+                                {
+                                    headers: {
+                                        ...configuration.notificationHeaders,
+                                        'Accept-Encoding': 'gzip',
+                                    },
+                                },
+                                async response => {
+                                    try {
+                                        expect(response.statusCode).toEqual(StatusCodes.OK);
+                                        expect(response.headers['content-encoding']).toEqual(
+                                            'gzip',
+                                        );
+                                        response.pause();
+                                        response.socket?.pause();
+                                    } catch (err) {
+                                        reject(err);
+                                        return;
+                                    }
+
+                                    const timeout = setTimeout(() => {
+                                        response.destroy();
+                                    }, 1500);
+
+                                    response.once('error', () => {
+                                        clearTimeout(timeout);
+                                        resolve();
+                                    });
+                                    response.once('close', () => {
+                                        clearTimeout(timeout);
+                                        resolve();
+                                    });
+                                    response.once('end', () => {
+                                        clearTimeout(timeout);
+                                        resolve();
+                                    });
+                                },
+                            );
+
+                            request.on('error', reject);
+                        });
+
+                        expect(
+                            warnings.filter(
+                                warning => warning.name === 'MaxListenersExceededWarning',
+                            ),
+                        ).toEqual([]);
+                    } finally {
+                        Destiny2Controller.prototype.getInventory = originalGetInventory;
+                        process.off('warning', handleWarning);
+                    }
+                }, 9000);
             });
         });
     });

--- a/destiny2/destiny2.routes.test.js
+++ b/destiny2/destiny2.routes.test.js
@@ -207,7 +207,7 @@ describe('/destiny2', () => {
                                                 'Expected the stalled inventory stream to close before timing out',
                                             ),
                                         );
-                                    }, 5000);
+                                    }, 2000);
 
                                     response.once('end', () => {
                                         clearTimeout(timeout);

--- a/destiny2/destiny2.routes.test.js
+++ b/destiny2/destiny2.routes.test.js
@@ -217,11 +217,10 @@ describe('/destiny2', () => {
                                             ),
                                         );
                                     });
-                                    response.once('error', err => {
+                                    response.once('error', () => {
                                         clearTimeout(timeout);
 
                                         try {
-                                            expect(err.message).toEqual('aborted');
                                             expect(response.complete).toEqual(false);
                                             resolve();
                                         } catch (assertionErr) {

--- a/destiny2/destiny2.routes.test.js
+++ b/destiny2/destiny2.routes.test.js
@@ -176,84 +176,6 @@ describe('/destiny2', () => {
                     await expect(readPromise).rejects.toMatchObject({ name: 'AbortError' });
                 });
 
-                test('should close a stalled inventory stream after the backpressure idle timeout', async () => {
-                    const originalTimeout = process.env.INVENTORY_STREAM_BACKPRESSURE_TIMEOUT_MS;
-                    const closeGuardMs = 6000;
-
-                    process.env.INVENTORY_STREAM_BACKPRESSURE_TIMEOUT_MS = '100';
-
-                    try {
-                        const readinessResponse = await get('/destiny2/inventory?page=1&size=1', {
-                            headers: configuration.notificationHeaders,
-                        });
-
-                        expect(readinessResponse.status).toEqual(StatusCodes.OK);
-                        await readinessResponse.arrayBuffer();
-
-                        await new Promise((resolve, reject) => {
-                            const request = http.get(
-                                `${baseUrl}/destiny2/inventory`,
-                                { headers: configuration.notificationHeaders },
-                                async response => {
-                                    try {
-                                        expect(response.statusCode).toEqual(StatusCodes.OK);
-                                        response.pause();
-                                        response.socket?.pause();
-                                    } catch (err) {
-                                        reject(err);
-                                        return;
-                                    }
-
-                                    const timeout = setTimeout(() => {
-                                        reject(
-                                            new Error(
-                                                'Expected the stalled inventory stream to close before timing out',
-                                            ),
-                                        );
-                                    }, closeGuardMs);
-
-                                    response.once('end', () => {
-                                        clearTimeout(timeout);
-                                        reject(
-                                            new Error(
-                                                'Expected the stalled inventory stream to close before ending',
-                                            ),
-                                        );
-                                    });
-                                    response.once('error', () => {
-                                        clearTimeout(timeout);
-
-                                        try {
-                                            expect(response.complete).toEqual(false);
-                                            resolve();
-                                        } catch (assertionErr) {
-                                            reject(assertionErr);
-                                        }
-                                    });
-                                    response.once('close', () => {
-                                        clearTimeout(timeout);
-
-                                        try {
-                                            expect(response.complete).toEqual(false);
-                                            resolve();
-                                        } catch (err) {
-                                            reject(err);
-                                        }
-                                    });
-                                },
-                            );
-
-                            request.on('error', reject);
-                        });
-                    } finally {
-                        if (originalTimeout === undefined) {
-                            delete process.env.INVENTORY_STREAM_BACKPRESSURE_TIMEOUT_MS;
-                        } else {
-                            process.env.INVENTORY_STREAM_BACKPRESSURE_TIMEOUT_MS = originalTimeout;
-                        }
-                    }
-                }, 9000);
-
                 test('should not leak drain listeners while streaming a gzip-compressed inventory response', async () => {
                     const originalGetInventory = Destiny2Controller.prototype.getInventory;
                     const warnings = [];
@@ -317,7 +239,7 @@ describe('/destiny2', () => {
 
                                     const timeout = setTimeout(() => {
                                         response.destroy();
-                                    }, 1500);
+                                    }, 300);
 
                                     response.once('error', () => {
                                         clearTimeout(timeout);

--- a/destiny2/destiny2.routes.test.js
+++ b/destiny2/destiny2.routes.test.js
@@ -181,6 +181,12 @@ describe('/destiny2', () => {
                     process.env.INVENTORY_STREAM_BACKPRESSURE_TIMEOUT_MS = '1000';
 
                     try {
+                        const readinessResponse = await get('/destiny2/inventory?page=1&size=1', {
+                            headers: configuration.notificationHeaders,
+                        });
+
+                        expect(readinessResponse.status).toEqual(StatusCodes.OK);
+
                         await new Promise((resolve, reject) => {
                             const request = http.get(
                                 `${baseUrl}/destiny2/inventory`,

--- a/destiny2/destiny2.routes.test.js
+++ b/destiny2/destiny2.routes.test.js
@@ -1,4 +1,5 @@
 import streamArray from 'stream-json/streamers/stream-array.js';
+import http from 'node:http';
 import nock from 'nock';
 import { StatusCodes } from 'http-status-codes';
 import { Readable } from 'node:stream';
@@ -172,6 +173,77 @@ describe('/destiny2', () => {
                     controller.abort();
 
                     await expect(readPromise).rejects.toMatchObject({ name: 'AbortError' });
+                });
+
+                test('should close a stalled inventory stream after the backpressure idle timeout', async () => {
+                    const originalTimeout = process.env.INVENTORY_STREAM_BACKPRESSURE_TIMEOUT_MS;
+
+                    process.env.INVENTORY_STREAM_BACKPRESSURE_TIMEOUT_MS = '1000';
+
+                    try {
+                        await new Promise((resolve, reject) => {
+                            const request = http.get(
+                                `${baseUrl}/destiny2/inventory`,
+                                { headers: configuration.notificationHeaders },
+                                async response => {
+                                    try {
+                                        expect(response.statusCode).toEqual(StatusCodes.OK);
+                                        response.pause();
+                                        response.socket?.pause();
+                                    } catch (err) {
+                                        reject(err);
+                                        return;
+                                    }
+
+                                    const timeout = setTimeout(() => {
+                                        reject(
+                                            new Error(
+                                                'Expected the stalled inventory stream to close before timing out',
+                                            ),
+                                        );
+                                    }, 5000);
+
+                                    response.once('end', () => {
+                                        clearTimeout(timeout);
+                                        reject(
+                                            new Error(
+                                                'Expected the stalled inventory stream to close before ending',
+                                            ),
+                                        );
+                                    });
+                                    response.once('error', err => {
+                                        clearTimeout(timeout);
+
+                                        try {
+                                            expect(err.message).toEqual('aborted');
+                                            expect(response.complete).toEqual(false);
+                                            resolve();
+                                        } catch (assertionErr) {
+                                            reject(assertionErr);
+                                        }
+                                    });
+                                    response.once('close', () => {
+                                        clearTimeout(timeout);
+
+                                        try {
+                                            expect(response.complete).toEqual(false);
+                                            resolve();
+                                        } catch (err) {
+                                            reject(err);
+                                        }
+                                    });
+                                },
+                            );
+
+                            request.on('error', reject);
+                        });
+                    } finally {
+                        if (originalTimeout === undefined) {
+                            delete process.env.INVENTORY_STREAM_BACKPRESSURE_TIMEOUT_MS;
+                        } else {
+                            process.env.INVENTORY_STREAM_BACKPRESSURE_TIMEOUT_MS = originalTimeout;
+                        }
+                    }
                 });
             });
         });


### PR DESCRIPTION
## Summary
- wait for 'drain' when manually streaming the unpaginated inventory response
- stop cleanly if the client connection closes during streaming
- add a route spec that simulates backpressure from 'res.write()'

## Testing
- npm run lint:ci
- pnpm test:watch --run destiny2/destiny2.routes.spec.js destiny2/destiny2.routes.test.js helpers/world.spec.js