### PR TITLE
fix(twilio): verify signature before authenticating user on /destiny/r

### DIFF
--- a/twilio/twilio.routes.js
+++ b/twilio/twilio.routes.js
@@ -50,30 +50,30 @@ const routes = ({
         NumMedia: z.coerce.number().int().min(0),
     });
 
-    twilioRouter.route('/destiny/r').post(async (req, res) => {
-        const header = req.headers['x-twilio-signature'];
-        const { body, cookies: requestCookies = {} } = req;
+    twilioRouter.route('/destiny/r').post(
+        async (req, res, next) => {
+            const header = req.headers['x-twilio-signature'];
+            const reconstructedUrl = `${process.env.PROTOCOL}://${process.env.DOMAIN}/twilio/destiny/r`;
 
-        // Reconstruct the URL using known, trusted components
-        const reconstructedUrl = `${process.env.PROTOCOL}://${process.env.DOMAIN}/twilio/destiny/r`;
+            if (!validateRequest(authToken, header, reconstructedUrl, req.body)) {
+                res.writeHead(StatusCodes.FORBIDDEN);
 
-        // Verify the request is genuinely from Twilio before doing anything
-        // else with it (schema validation, user lookups, etc).
-        if (!validateRequest(authToken, header, reconstructedUrl, body)) {
-            res.writeHead(StatusCodes.FORBIDDEN);
+                return res.end();
+            }
 
-            return res.end();
-        }
-
-        try {
-            bodySchema.parse(body);
-        } catch (err) {
-            return res.status(StatusCodes.BAD_REQUEST).json({ error: err.issues[0].message });
-        }
-
-        // Only look up/authenticate the user once the request has been
-        // verified as an authentic, well-formed Twilio callback.
-        return middleware.authenticateUser(req, res, async () => {
+            next();
+        },
+        async (req, res, next) => {
+            try {
+                bodySchema.parse(req.body);
+                next();
+            } catch (err) {
+                return res.status(StatusCodes.BAD_REQUEST).json({ error: err.issues[0].message });
+            }
+        },
+        (req, res, next) => middleware.authenticateUser(req, res, next),
+        async (req, res) => {
+            const { body, cookies: requestCookies = {} } = req;
             const {
                 cookies = {},
                 media,
@@ -109,8 +109,8 @@ const routes = ({
             });
 
             return res.end(twiml.toString());
-        });
-    });
+        },
+    );
 
     twilioRouter.route('/destiny/s').post(async (req, res) => {
         const header = req.headers['x-twilio-signature'];

--- a/twilio/twilio.routes.js
+++ b/twilio/twilio.routes.js
@@ -51,7 +51,7 @@ const routes = ({
     });
 
     twilioRouter.route('/destiny/r').post(
-        async (req, res, next) => {
+        (req, res, next) => {
             const header = req.headers['x-twilio-signature'];
             const reconstructedUrl = `${process.env.PROTOCOL}://${process.env.DOMAIN}/twilio/destiny/r`;
 
@@ -61,12 +61,13 @@ const routes = ({
                 return res.end();
             }
 
-            next();
+            return next();
         },
-        async (req, res, next) => {
+        (req, res, next) => {
             try {
                 bodySchema.parse(req.body);
-                next();
+
+                return next();
             } catch (err) {
                 return res.status(StatusCodes.BAD_REQUEST).json({ error: err.issues[0].message });
             }

--- a/twilio/twilio.routes.js
+++ b/twilio/twilio.routes.js
@@ -50,27 +50,30 @@ const routes = ({
         NumMedia: z.coerce.number().int().min(0),
     });
 
-    twilioRouter.route('/destiny/r').post(
-        async (req, res, next) => await middleware.authenticateUser(req, res, next),
-        async (req, res) => {
-            const header = req.headers['x-twilio-signature'];
-            const { body, cookies: requestCookies = {} } = req;
+    twilioRouter.route('/destiny/r').post(async (req, res) => {
+        const header = req.headers['x-twilio-signature'];
+        const { body, cookies: requestCookies = {} } = req;
 
-            try {
-                bodySchema.parse(body);
-            } catch (err) {
-                return res.status(StatusCodes.BAD_REQUEST).json({ error: err.issues[0].message });
-            }
+        // Reconstruct the URL using known, trusted components
+        const reconstructedUrl = `${process.env.PROTOCOL}://${process.env.DOMAIN}/twilio/destiny/r`;
 
-            // Reconstruct the URL using known, trusted components
-            const reconstructedUrl = `${process.env.PROTOCOL}://${process.env.DOMAIN}/twilio/destiny/r`;
+        // Verify the request is genuinely from Twilio before doing anything
+        // else with it (schema validation, user lookups, etc).
+        if (!validateRequest(authToken, header, reconstructedUrl, body)) {
+            res.writeHead(StatusCodes.FORBIDDEN);
 
-            if (!validateRequest(authToken, header, reconstructedUrl, body)) {
-                res.writeHead(StatusCodes.FORBIDDEN);
+            return res.end();
+        }
 
-                return res.end();
-            }
+        try {
+            bodySchema.parse(body);
+        } catch (err) {
+            return res.status(StatusCodes.BAD_REQUEST).json({ error: err.issues[0].message });
+        }
 
+        // Only look up/authenticate the user once the request has been
+        // verified as an authentic, well-formed Twilio callback.
+        return middleware.authenticateUser(req, res, async () => {
             const {
                 cookies = {},
                 media,
@@ -106,8 +109,8 @@ const routes = ({
             });
 
             return res.end(twiml.toString());
-        },
-    );
+        });
+    });
 
     twilioRouter.route('/destiny/s').post(async (req, res) => {
         const header = req.headers['x-twilio-signature'];


### PR DESCRIPTION
## Problem
`authenticateUser` middleware ran before the Twilio signature was validated on the inbound SMS webhook route (`/twilio/destiny/r`). Since `authenticateUser` looks up a user by the (attacker-controlled, unverified) `From` phone number, a forged webhook request could trigger a real user cache/DB lookup and a Bungie token refresh before the request was confirmed to actually originate from Twilio.

## Fix
Reordered the handler so:
1. `validateRequest()` (Twilio signature check) runs first
2. Body schema validation runs second
3. `authenticateUser` (and the resulting user lookup) runs last, only for verified, well-formed requests

No behavior change for legitimate Twilio traffic -- forged/malformed requests are now rejected earlier and more cheaply.

Found during a security review of `main`.