### PR TITLE
ci: add lint/typecheck/openapi CI, CodeQL, and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  # Application dependencies (pnpm).
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      # Batch routine minor/patch bumps into a single PR to cut noise.
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # Keep the GitHub Actions in .github/workflows pinned and current.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,15 @@ jobs:
 
       # Regenerate the spec from JSDoc and fail if it differs from the
       # committed openapi.json — keeps the API docs from silently rotting.
+      # NODE_ENV is pinned because openapi.cjs selects the server URL from it,
+      # so the output must match the environment the committed spec was built in.
       - name: Check OpenAPI spec is up to date
+        env:
+          NODE_ENV: development
         run: |
           pnpm swagger
-          git diff --exit-code -- openapi.json \
-            || (echo "::error::openapi.json is out of date. Run 'pnpm swagger' and commit the result." && exit 1)
+          if ! git diff --quiet -- openapi.json; then
+            echo "::error::openapi.json is out of date. Run 'pnpm swagger' and commit the result."
+            git diff -- openapi.json
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel in-progress runs for the same ref (e.g. new pushes to a PR).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: lint, typecheck, openapi
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      # Also validates that package.json and pnpm-lock.yaml are in sync.
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint:ci
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      # Regenerate the spec from JSDoc and fail if it differs from the
+      # committed openapi.json — keeps the API docs from silently rotting.
+      - name: Check OpenAPI spec is up to date
+        run: |
+          pnpm swagger
+          git diff --exit-code -- openapi.json \
+            || (echo "::error::openapi.json is out of date. Run 'pnpm swagger' and commit the result." && exit 1)

--- a/.github/workflows/codacy-coverage-reporter.yml
+++ b/.github/workflows/codacy-coverage-reporter.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     name: codacy-coverage-reporter
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run codacy-coverage-reporter
         uses: codacy/codacy-coverage-reporter-action@master
         with:

--- a/.github/workflows/codacy-coverage-reporter.yml
+++ b/.github/workflows/codacy-coverage-reporter.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run codacy-coverage-reporter
-        uses: codacy/codacy-coverage-reporter-action@master
+        uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699 # v1.3.0
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: coverage/clover.xml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       # Job-level permissions replace (not merge with) the workflow-level
-      # block, so contents:read must be restated for actions/checkout.
+      # block, so read scopes must be restated here.
+      actions: read # required by the CodeQL action for private repositories
       contents: read
       security-events: write
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,31 @@
+name: codeql
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly re-scan so newly disclosed patterns catch existing code.
+    - cron: '27 4 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          queries: security-extended
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,6 +17,9 @@ jobs:
     name: analyze
     runs-on: ubuntu-latest
     permissions:
+      # Job-level permissions replace (not merge with) the workflow-level
+      # block, so contents:read must be restated for actions/checkout.
+      contents: read
       security-events: write
     steps:
       - uses: actions/checkout@v4

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.1",
   "info": {
     "title": "Destiny-Ghost API",
-    "version": "2.12.0",
+    "version": "2.14.0",
     "description": "A Node Express application for receiving SMS/MMS Notifications around changes to the vendor wares in Bungie's Destiny and make ad-hoc queries in the database.",
     "license": {
       "name": "MIT",


### PR DESCRIPTION
## Summary

Adds hermetic GitHub Actions that run **without** `settings/` or any secrets, so CI can gate PRs without exposing configuration. Test execution is intentionally left out because the suite requires the gitignored `settings/` config.

### Workflows
- **`ci.yml`** — on push to `main` and all PRs (with concurrency cancellation). One `verify` job:
  - `pnpm install --frozen-lockfile` — also gates `package.json`/lockfile drift
  - `pnpm lint:ci` (Biome)
  - `pnpm typecheck` (`tsc --noEmit`)
  - **OpenAPI drift check** — regenerates the spec from JSDoc and fails if it differs from the committed `openapi.json`
- **`codeql.yml`** — CodeQL `security-extended` scan on push/PR + weekly cron; `security-events: write` scoped to the analyze job only.
- **`dependabot.yml`** — weekly `npm` updates (minor/patch grouped into one PR) and `github-actions` updates to keep workflow pins current.

### Other changes
- Pinned `actions/checkout@master` → `@v4` in the Codacy workflow (reproducibility + supply-chain).
- Regenerated `openapi.json`, which had drifted to `2.12.0` while `package.json` is `2.14.0` — the first thing the new drift check caught.

## Verification
All three hermetic checks were run locally and pass:
- `pnpm lint:ci` ✓
- `pnpm typecheck` ✓
- `pnpm swagger` output is deterministic (two regenerations byte-identical), so the drift check won't be flaky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)