### PR TITLE
chore(dependabot): group github-actions bumps into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,9 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      # Batch all action bumps into a single PR to avoid the rebase cascade
+      # that separate PRs cause under strict, up-to-date-required checks.
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Add a wildcard `groups` block to the `github-actions` ecosystem in `dependabot.yml` so every action version bump lands in a **single** weekly PR.

## Why

The four action bumps that just came through (#627–#630) arrived as four separate PRs. Because they all edit the workflow files and `main` requires **strict, up-to-date** status checks, merging one invalidated the rest — each had to rebase and re-run CI before it could merge, a rebase cascade. Grouping collapses that into one PR.

This mirrors the existing `minor-and-patch` group already used for the npm ecosystem.

## Change

```yaml
  - package-ecosystem: github-actions
    directory: /
    schedule:
      interval: weekly
    groups:
      actions:
        patterns:
          - "*"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)