### PR TITLE
fix(loaders): replace always-truthy res.status guard with res.headersSent

### DIFF
--- a/loaders/index.js
+++ b/loaders/index.js
@@ -83,7 +83,7 @@ const loaders = {
 
             log.error(err);
 
-            if (res.status) {
+            if (!res.headersSent) {
                 if (err instanceof DestinyError) {
                     res.status(StatusCodes.NOT_FOUND).json({
                         errors: [


### PR DESCRIPTION
## Bug

In `loaders/index.js`, the Express error-handler middleware guarded its response logic with:

```js
if (res.status) {
```

`res.status` is always a **function** on an Express `Response` object — it's the method used to set the HTTP status code (e.g. `res.status(404)`). Functions are always truthy in JavaScript, so this condition is permanently `true` and the `else { next(err) }` branch is **unreachable dead code**.

This means if headers had already been sent (e.g. a previous middleware partially responded), the error handler would attempt to call `res.status(...).json(...)` again, causing the `"Cannot set headers after they are sent to the client"` crash instead of gracefully delegating to the next error handler.

## Fix

Replace `res.status` with `res.headersSent`, the correct Express boolean flag that indicates whether the response headers have already been flushed:

```js
if (!res.headersSent) {
    // safe to send error response
} else {
    next(err); // headers already sent — delegate downstream
}
```

## Test plan

- [x] All 466 existing tests pass
- [x] Error handler now correctly delegates via `next(err)` when headers have already been sent