### PR TITLE
fix(session): stop persisting anonymous sessions and simplify store guard

### DIFF
--- a/helpers/httpLog.js
+++ b/helpers/httpLog.js
@@ -27,7 +27,7 @@ class HttpLog extends PinoHttp {
             },
             customReceivedObject: (req, res, loggableObject) => {
                 const {
-                    session: { displayName, membershipType },
+                    session: { displayName, membershipType } = {},
                     body: { From: phoneNumber } = {},
                 } = req;
                 const { traceId } = context.getStore()?.get('logger')?.bindings() || {};

--- a/loaders/express.js
+++ b/loaders/express.js
@@ -90,10 +90,13 @@ export default app => {
     /**
      * If the Redis store is disconnected, express-session calls next() without
      * setting req.session. Fail fast with an explicit error rather than letting
-     * the request proceed sessionless.
+     * the request proceed sessionless. Liveness and health endpoints are exempt
+     * so they can still report diagnostics during a session store outage.
      */
     app.use((req, _res, next) => {
-        if (!req.session) {
+        const isSessionless = req.path === '/ping' || req.path.startsWith('/health');
+
+        if (!isSessionless && !req.session) {
             const error = new Error('Session store unavailable.');
 
             error.statusCode = StatusCodes.SERVICE_UNAVAILABLE;

--- a/loaders/express.js
+++ b/loaders/express.js
@@ -94,7 +94,7 @@ export default app => {
      * so they can still report diagnostics during a session store outage.
      */
     app.use((req, _res, next) => {
-        const isSessionless = req.path === '/ping' || req.path.startsWith('/health');
+        const isSessionless = /^\/(?:ping|health)(?:\/|$)/.test(req.path);
 
         if (!isSessionless && !req.session) {
             const error = new Error('Session store unavailable.');

--- a/loaders/express.js
+++ b/loaders/express.js
@@ -63,33 +63,24 @@ export default app => {
         },
         name: configuration.session.cookie.name,
         resave: false,
-        saveUninitialized: true,
+        saveUninitialized: false,
         secret: configuration.session.secret,
         store,
     });
 
-    app.use((req, res, next) => {
-        let numberOfRetries = 3;
+    app.use(ghostSession);
 
-        function lookupSession(err) {
-            if (err) {
-                return next(err);
-            }
-
-            numberOfRetries -= 1;
-
-            if (req.session !== undefined) {
-                return next();
-            }
-
-            if (numberOfRetries < 0) {
-                return next(new Error('Failed to look up session.'));
-            }
-
-            return ghostSession(req, res, lookupSession);
+    /**
+     * If the Redis store is disconnected, express-session calls next() without
+     * setting req.session. Fail fast with an explicit error rather than letting
+     * the request proceed sessionless.
+     */
+    app.use((req, _res, next) => {
+        if (!req.session) {
+            return next(new Error('Session store unavailable.'));
         }
 
-        lookupSession();
+        return next();
     });
 
     /**

--- a/loaders/express.js
+++ b/loaders/express.js
@@ -3,6 +3,7 @@ import cookieParser from 'cookie-parser';
 import express from 'express';
 import session from 'express-session';
 import helmet from 'helmet';
+import { StatusCodes } from 'http-status-codes';
 
 import configuration from '../helpers/config.js';
 import httpLog from '../helpers/httpLog.js';
@@ -79,25 +80,29 @@ export default app => {
     app.use(ghostSession);
 
     /**
+     * Request/Response and Error Loggers
+     *
+     * Runs before the session guard so requests still get correlation
+     * headers and structured logs during a session store outage.
+     */
+    app.use(httpLog);
+
+    /**
      * If the Redis store is disconnected, express-session calls next() without
      * setting req.session. Fail fast with an explicit error rather than letting
      * the request proceed sessionless.
      */
     app.use((req, _res, next) => {
         if (!req.session) {
-            return next(new Error('Session store unavailable.'));
+            const error = new Error('Session store unavailable.');
+
+            error.statusCode = StatusCodes.SERVICE_UNAVAILABLE;
+
+            return next(error);
         }
 
         return next();
     });
-
-    /**
-     * Request/Response and Error Loggers
-     *
-     * Must stay behind the session guard: httpLog destructures req.session
-     * and would throw if it ran while the session store is unavailable.
-     */
-    app.use(httpLog);
 
     /**
      * Rate Limiter

--- a/loaders/express.js
+++ b/loaders/express.js
@@ -47,6 +47,14 @@ export default app => {
     });
 
     /**
+     * Attach Context
+     *
+     * Runs before the session middleware so that errors raised there, e.g.
+     * when the session store is unavailable, are logged with a traceId.
+     */
+    app.use(contextMiddleware);
+
+    /**
      * Attach Session
      */
     if (process.env.NODE_ENV === 'production') {
@@ -84,12 +92,10 @@ export default app => {
     });
 
     /**
-     * Attach Context
-     */
-    app.use(contextMiddleware);
-
-    /**
      * Request/Response and Error Loggers
+     *
+     * Must stay behind the session guard: httpLog destructures req.session
+     * and would throw if it ran while the session store is unavailable.
      */
     app.use(httpLog);
 

--- a/loaders/index.js
+++ b/loaders/index.js
@@ -79,7 +79,7 @@ const loaders = {
         });
 
         app.use((err, _req, res, next) => {
-            const { code, message, status, statusText } = err;
+            const { code, message, status, statusCode, statusText } = err;
 
             log.error(err);
 
@@ -104,7 +104,7 @@ const loaders = {
                         ],
                     });
                 } else {
-                    res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+                    res.status(statusCode ?? StatusCodes.INTERNAL_SERVER_ERROR).json({
                         errors: [
                             {
                                 message,

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.1",
   "info": {
     "title": "Destiny-Ghost API",
-    "version": "2.14.0",
+    "version": "2.15.0",
     "description": "A Node Express application for receiving SMS/MMS Notifications around changes to the vendor wares in Bungie's Destiny and make ad-hoc queries in the database.",
     "license": {
       "name": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "destiny-ghost-api",
-    "version": "2.14.0",
+    "version": "2.15.0",
     "description": "Node.js API for querying the Destiny database via SMS messages.",
     "main": "start.js",
     "type": "module",


### PR DESCRIPTION
## Summary

Addresses review feedback on the session configuration in `loaders/express.js`:

- **`saveUninitialized: false`** — anonymous requests (bots hitting `/`, `/ping`, `/docs`) no longer write empty sessions to Redis, keeping the session store lean. The OAuth sign-in flow is unaffected: `/destiny/signIn` writes `req.session.state`, which marks the session as modified so it is still persisted and the cookie still set.
- **Replace the 3-retry session lookup loop with a fail-fast guard** — the retry loop was a legacy pattern from an old connect-redis FAQ; its immediate back-to-back retries rarely help when Redis is actually down. The guard provides the same protection with less machinery: if the Redis store is disconnected, express-session calls `next()` without setting `req.session`, and the guard surfaces an explicit `Session store unavailable.` error instead of letting the request proceed sessionless.
- **Bump version to 2.15.0** — `openapi.json` regenerated via `npm run swagger` (version flows from `package.json`).

## Testing

- Full test suite passes: 466 passed, 1 skipped (45 files).
- Lint (Biome) clean.
- OAuth flow traced: `req.session.state` write in `destiny/destiny.routes.js` keeps the pre-login session persisted under `saveUninitialized: false`; the rate limiter falls back to IP when no session data exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)