### PR TITLE
fix(cors): centralize CORS handling on the cors package

### DIFF
--- a/destiny/destiny.routes.js
+++ b/destiny/destiny.routes.js
@@ -2,13 +2,11 @@
  * Created by chris on 9/25/15.
  */
 import { StatusCodes } from 'http-status-codes';
-import cors from 'cors';
 import { Router } from 'express';
 import DestinyController from './destiny.controller.js';
 import authorizeUser from '../authorization/authorization.middleware.js';
 import getMaxAgeFromCacheControl from '../helpers/get-max-age-from-cache-control.js';
 import toTemporalInstant from '../helpers/to-temporal-instant.js';
-import configuration from '../helpers/config.js';
 
 /**
  * Destiny Routes
@@ -32,7 +30,7 @@ const routes = ({ destinyService, userService, worldRepository }) => {
         worldRepository,
     });
 
-    destinyRouter.route('/signIn/').get(cors(configuration.cors), async (req, res) => {
+    destinyRouter.route('/signIn/').get(async (req, res) => {
         const { state, url } = await destinyController.getAuthorizationUrl();
 
         req.session.state = state;
@@ -86,27 +84,25 @@ const routes = ({ destinyService, userService, worldRepository }) => {
      *        422:
      *          description: Unrecognized whole number.
      */
-    destinyRouter
-        .route('/grimoireCards/:numberOfCards')
-        .get(cors(configuration.cors), async (req, res) => {
-            const {
-                params: { numberOfCards },
-            } = req;
-            const count = parseInt(numberOfCards, 10);
+    destinyRouter.route('/grimoireCards/:numberOfCards').get(async (req, res) => {
+        const {
+            params: { numberOfCards },
+        } = req;
+        const count = parseInt(numberOfCards, 10);
 
-            if (Number.isNaN(count)) {
-                return res.status(StatusCodes.UNPROCESSABLE_ENTITY).end();
-            }
+        if (Number.isNaN(count)) {
+            return res.status(StatusCodes.UNPROCESSABLE_ENTITY).end();
+        }
 
-            if (count < 1 || count > 10) {
-                return res
-                    .status(StatusCodes.BAD_REQUEST)
-                    .send('Must be a whole number less than or equal to 10.');
-            }
+        if (count < 1 || count > 10) {
+            return res
+                .status(StatusCodes.BAD_REQUEST)
+                .send('Must be a whole number less than or equal to 10.');
+        }
 
-            const grimoireCards = await destinyController.getGrimoireCards(count);
-            res.status(StatusCodes.OK).json(grimoireCards);
-        });
+        const grimoireCards = await destinyController.getGrimoireCards(count);
+        res.status(StatusCodes.OK).json(grimoireCards);
+    });
 
     /**
      * @openapi

--- a/destiny2/destiny2.routes.js
+++ b/destiny2/destiny2.routes.js
@@ -2,15 +2,12 @@
  * Created by chris on 9/25/15.
  */
 import { StatusCodes } from 'http-status-codes';
-import cors from 'cors';
 import { Router } from 'express';
 import AuthenticationMiddleware from '../authentication/authentication.middleware.js';
 import authorizeUser from '../authorization/authorization.middleware.js';
 import getMaxAgeFromCacheControl from '../helpers/get-max-age-from-cache-control.js';
 import log from '../helpers/log.js';
 import toTemporalInstant from '../helpers/to-temporal-instant.js';
-
-import configuration from '../helpers/config.js';
 
 const inventoryStreamBackpressureIdleTimeoutMs = 30 * 1000;
 const inventoryStreamWriteResult = Object.freeze({
@@ -375,7 +372,6 @@ const routes = ({ authenticationController, destiny2Controller }) => {
      *          description: Xur could not be found.
      */
     destiny2Router.route('/xur').get(
-        cors(configuration.cors),
         async (req, res, next) => await middleware.authenticateUser(req, res, next),
         async (req, res) => {
             const {

--- a/health/health.routes.js
+++ b/health/health.routes.js
@@ -1,8 +1,6 @@
 import { Router } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import HealthController from './health.controller.js';
-import cors from 'cors';
-import configuration from '../helpers/config.js';
 
 /**
  * Destiny Routes
@@ -21,8 +19,6 @@ const routes = ({
     world2Repository,
 }) => {
     const healthRouter = Router();
-
-    healthRouter.use(cors(configuration.cors));
 
     /**
      * Set up routes and initialize the controller.

--- a/loaders/express.js
+++ b/loaders/express.js
@@ -1,5 +1,6 @@
 import compression from 'compression';
 import cookieParser from 'cookie-parser';
+import cors from 'cors';
 import express from 'express';
 import session from 'express-session';
 import helmet from 'helmet';
@@ -38,14 +39,9 @@ export default app => {
     app.disable('etag').disable('x-powered-by');
 
     /**
-     * Set Access Headers
+     * Cross-Origin Resource Sharing
      */
-    app.use((_req, res, next) => {
-        res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE');
-        res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-        res.setHeader('Access-Control-Allow-Credentials', true);
-        next();
-    });
+    app.use(cors(configuration.cors));
 
     /**
      * Attach Context

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.1",
   "info": {
     "title": "Destiny-Ghost API",
-    "version": "2.15.0",
+    "version": "2.16.0",
     "description": "A Node Express application for receiving SMS/MMS Notifications around changes to the vendor wares in Bungie's Destiny and make ad-hoc queries in the database.",
     "license": {
       "name": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "destiny-ghost-api",
-    "version": "2.15.0",
+    "version": "2.16.0",
     "description": "Node.js API for querying the Destiny database via SMS messages.",
     "main": "start.js",
     "type": "module",

--- a/users/user.routes.js
+++ b/users/user.routes.js
@@ -1,9 +1,7 @@
 import { StatusCodes } from 'http-status-codes';
-import cors from 'cors';
 import { Router } from 'express';
 import AuthenticationMiddleWare from '../authentication/authentication.middleware.js';
 import UserController from './user.controller.js';
-import configuration from '../helpers/config.js';
 import log from '../helpers/log.js';
 
 /**
@@ -92,8 +90,6 @@ const routes = ({
         worldRepository,
     });
     const userRouter = Router();
-
-    userRouter.use(cors(configuration.cors));
 
     /**
      * @openapi


### PR DESCRIPTION
## Summary
- Replace the manual `Access-Control-Allow-*` header middleware in `loaders/express.js` with a single global `cors(configuration.cors)` mount before the session middleware
- Remove the redundant per-router/per-route `cors()` usages (and now-unused `cors`/`configuration` imports) from the users, health, destiny, and destiny2 routers
- Bump version to 2.16.0

## Why
The manual header block set `Access-Control-Allow-Credentials: true` on every response but never set `Access-Control-Allow-Origin`, so it granted nothing to browsers. Worse, on routes where the `cors` package also ran with a default/wildcard origin, the lingering credentials header risked the spec-forbidden `Allow-Origin: *` + `Allow-Credentials: true` combination. It also never short-circuited `OPTIONS` preflights, so non-simple cross-origin requests failed preflight on routes covered only by the manual block.

Centralizing on the `cors` package gives every route a consistent explicit origin allowlist, credentialed responses paired with an exact origin echo, and proper preflight handling (honoring the configured `optionsSuccessStatus`).

## Test plan
- [x] `pnpm test` — 466 passed, 1 skipped (also enforced by the pre-commit hook)
- [x] `biome check` clean on all modified files
- [ ] Verify credentialed cross-origin requests from `https://app.destiny-ghost.com` against production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)