### PR TITLE
feat(destiny): fail fast on Bungie outages with an opossum circuit breaker

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -41,10 +41,6 @@ The application has been instrumented with Application Insights, but custom tele
 * Evaluate how to capture application metrics like Node performance.
 * Consider OpenTelemetry for distributed tracing.
 
-## Circuit Breaker
-
-Bungie's API is a external dependency that could be unreliable. Implement a circuit breaker to prevent the application from making requests to the API when it is down. Check out [Opossum](https://github.com/nodeshift/opossum) for a Node.js circuit breaker.
-
 ## Manifest Refresh
 
 Add a timer to automatically refresh the manifest file when Bungie releases a new version.

--- a/destiny/destiny.service.js
+++ b/destiny/destiny.service.js
@@ -10,7 +10,7 @@
  * the Bungie web API platform help page {@link https://www.bungie.net/platform/destiny/help/}.
  */
 import { stringify } from 'qs';
-import { get, post } from '../helpers/request.js';
+import { get, post } from '../helpers/bungie.request.js';
 import DestinyError from './destiny.error.js';
 import configuration from '../helpers/config.js';
 
@@ -108,7 +108,7 @@ class DestinyService {
             url: `${servicePlatform}/app/oauth/token/`,
         };
 
-        return await post(options, { maxRetries: 3 });
+        return await post(options);
     }
 
     /**

--- a/destiny/destiny.service.spec.js
+++ b/destiny/destiny.service.spec.js
@@ -3,12 +3,12 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import Chance from 'chance';
-import { get } from '../helpers/request.js';
+import { get } from '../helpers/bungie.request.js';
 import DestinyError from './destiny.error.js';
 import DestinyService from './destiny.service.js';
 import mockManifestResponse from '../mocks/manifestResponse.json';
 
-vi.mock('../helpers/request.js');
+vi.mock('../helpers/bungie.request.js');
 
 let destinyService;
 

--- a/destiny2/destiny2.service.js
+++ b/destiny2/destiny2.service.js
@@ -14,7 +14,7 @@ import DestinyService from '../destiny/destiny.service.js';
 import configuration from '../helpers/config.js';
 import log from '../helpers/log.js';
 import { strangeGearOffersHash } from './destiny2.constants.js';
-import { get, post } from '../helpers/request.js';
+import { get, post } from '../helpers/bungie.request.js';
 
 const {
     bungie: { apiKey, host },
@@ -54,7 +54,7 @@ class Destiny2Service extends DestinyService {
             },
             url: `${servicePlatform}/User/Search/GlobalName/${pageNumber}/`,
         };
-        const responseBody = await post(options, { maxRetries: 3 });
+        const responseBody = await post(options);
 
         if (responseBody.ErrorCode === 1) {
             const {

--- a/destiny2/destiny2.service.spec.js
+++ b/destiny2/destiny2.service.spec.js
@@ -8,9 +8,9 @@ import mockManifestResponse from '../mocks/manifestResponse.json';
 import mockProfileCharactersResponse from '../mocks/profileCharactersResponse.json';
 import mockPlayerStatisticsResponse from '../mocks/playerStatisticsResponse.json';
 import mockXurResponse from '../mocks/xurResponse.json';
-import { get, post } from '../helpers/request.js';
+import { get, post } from '../helpers/bungie.request.js';
 
-vi.mock('../helpers/request.js');
+vi.mock('../helpers/bungie.request.js');
 
 const mockUser = {
     membershipId: '11',

--- a/health/health.controller.js
+++ b/health/health.controller.js
@@ -8,6 +8,7 @@ import { getHeapStatistics } from 'v8';
 import { convert } from 'html-to-text';
 
 import { get } from '../helpers/request.js';
+import { getCircuitBreakerStatus } from '../helpers/bungie.request.js';
 import applicationInsights from '../helpers/application-insights.js';
 import log from '../helpers/log.js';
 
@@ -161,6 +162,10 @@ class HealthController {
         return {
             failures,
             health: {
+                // Reported for observability only: an open breaker means
+                // Bungie is down, not this service, so it never counts as
+                // a failure.
+                bungie: getCircuitBreakerStatus(),
                 documents,
                 twilio,
                 destiny: {

--- a/health/health.controller.spec.js
+++ b/health/health.controller.spec.js
@@ -6,6 +6,12 @@ import manifestResponse from '../mocks/manifestResponse.json';
 import manifest2Response from '../mocks/manifest2Response.json';
 
 vi.mock('../helpers/request.js');
+vi.mock('../helpers/bungie.request.js', () => ({
+    getCircuitBreakerStatus: vi.fn(() => ({
+        state: 'closed',
+        stats: { failures: 0, rejects: 0, successes: 0, timeouts: 0 },
+    })),
+}));
 vi.mock('../helpers/application-insights.js', () => ({
     default: {
         trackMetric: vi.fn(),
@@ -97,6 +103,10 @@ describe('HealthController', () => {
 
                 expect(failures).toEqual(0);
                 expect(health).toEqual({
+                    bungie: {
+                        state: 'closed',
+                        stats: { failures: 0, rejects: 0, successes: 0, timeouts: 0 },
+                    },
                     documents: 2,
                     twilio: 'All Systems Go',
                     destiny: {
@@ -156,6 +166,10 @@ describe('HealthController', () => {
 
                 expect(failures).toEqual(6);
                 expect(health).toEqual({
+                    bungie: {
+                        state: 'closed',
+                        stats: { failures: 0, rejects: 0, successes: 0, timeouts: 0 },
+                    },
                     documents: -1,
                     twilio: 'N/A',
                     destiny: {

--- a/health/health.routes.spec.js
+++ b/health/health.routes.spec.js
@@ -8,6 +8,12 @@ import manifestResponse from '../mocks/manifestResponse.json';
 import manifest2Response from '../mocks/manifest2Response.json';
 
 vi.mock('../helpers/request.js');
+vi.mock('../helpers/bungie.request.js', () => ({
+    getCircuitBreakerStatus: vi.fn(() => ({
+        state: 'closed',
+        stats: { failures: 0, rejects: 0, successes: 0, timeouts: 0 },
+    })),
+}));
 
 const { Response: manifest } = manifestResponse;
 const { Response: manifest2 } = manifest2Response;
@@ -91,6 +97,10 @@ describe('HealthRouter', () => {
                     const body = JSON.parse(res._getData());
 
                     expect(body).toEqual({
+                        bungie: {
+                            state: 'closed',
+                            stats: { failures: 0, rejects: 0, successes: 0, timeouts: 0 },
+                        },
                         documents: 2,
                         twilio: 'All Systems Go',
                         destiny: {
@@ -148,6 +158,10 @@ describe('HealthRouter', () => {
                     const body = JSON.parse(res._getData());
 
                     expect(body).toEqual({
+                        bungie: {
+                            state: 'closed',
+                            stats: { failures: 0, rejects: 0, successes: 0, timeouts: 0 },
+                        },
                         documents: -1,
                         twilio: 'N/A',
                         destiny: {

--- a/helpers/bungie.request.js
+++ b/helpers/bungie.request.js
@@ -37,6 +37,10 @@ const options = {
 // The breaker owns outage handling, so one quick retry replaces the
 // request helper's default ladder of three with long backoff.
 const retryDefaults = { baseDelay: 500, maxDelay: 1000, maxRetries: 1 };
+// The socket abort trails the breaker timeout so opossum deterministically
+// rejects first with ETIMEDOUT (and counts it in stats.timeouts); the abort
+// then tears down the socket shortly after.
+const socketTimeout = options.timeout + 1000;
 
 const breaker = new CircuitBreaker((fn, ...args) => fn(...args), options);
 
@@ -66,11 +70,13 @@ async function fire(fn, ...args) {
 }
 
 /**
- * Cap every attempt with a timeout signal that actually aborts the socket;
- * opossum's timeout only rejects. Retry backoff sleeps are not cancelled,
- * but once the timeout fires any subsequent attempt rejects immediately.
- * A caller-provided signal is combined, not replaced, so the timeout
- * always applies.
+ * Cap every attempt with a signal that actually aborts the socket;
+ * opossum's timeout only rejects. The abort fires after the breaker
+ * timeout, so callers consistently see ETIMEDOUT rather than racing it
+ * with an AbortError. Retry backoff sleeps are not cancelled, but once
+ * the signal fires any subsequent attempt rejects immediately. A
+ * caller-provided signal is combined, not replaced, so the cap always
+ * applies.
  *
  * @param {object} requestOptions
  * @returns {object}
@@ -78,8 +84,8 @@ async function fire(fn, ...args) {
 const withSignal = ({ signal, ...requestOptions } = {}) => ({
     ...requestOptions,
     signal: signal
-        ? AbortSignal.any([signal, AbortSignal.timeout(options.timeout)])
-        : AbortSignal.timeout(options.timeout),
+        ? AbortSignal.any([signal, AbortSignal.timeout(socketTimeout)])
+        : AbortSignal.timeout(socketTimeout),
 });
 
 /**

--- a/helpers/bungie.request.js
+++ b/helpers/bungie.request.js
@@ -66,15 +66,20 @@ async function fire(fn, ...args) {
 }
 
 /**
- * Bound the whole logical call (attempt + backoff + retry) with a signal
- * that actually cancels the socket; opossum's timeout only rejects.
+ * Cap every attempt with a timeout signal that actually aborts the socket;
+ * opossum's timeout only rejects. Retry backoff sleeps are not cancelled,
+ * but once the timeout fires any subsequent attempt rejects immediately.
+ * A caller-provided signal is combined, not replaced, so the timeout
+ * always applies.
  *
  * @param {object} requestOptions
  * @returns {object}
  */
-const withSignal = requestOptions => ({
-    signal: AbortSignal.timeout(options.timeout),
+const withSignal = ({ signal, ...requestOptions } = {}) => ({
     ...requestOptions,
+    signal: signal
+        ? AbortSignal.any([signal, AbortSignal.timeout(options.timeout)])
+        : AbortSignal.timeout(options.timeout),
 });
 
 /**

--- a/helpers/bungie.request.js
+++ b/helpers/bungie.request.js
@@ -1,0 +1,121 @@
+/**
+ * A circuit-breaker-protected HTTP client for the Bungie web API.
+ *
+ * @module bungieRequest
+ * @summary Wraps the request helper's get/post in a shared opossum circuit breaker.
+ * @description All Bungie traffic shares a single breaker: Bungie outages
+ * (e.g. maintenance windows) are platform-wide, so pooled failure statistics
+ * detect them fastest. Cache-aside reads in the services happen before these
+ * functions are called, so cached data keeps serving while the circuit is
+ * open; cache misses fail fast with a 503. Known limitation: Bungie sometimes
+ * signals maintenance as HTTP 200 with a body ErrorCode of 5 — those surface
+ * as DestinyError above this layer and do not trip the breaker.
+ */
+import CircuitBreaker from 'opossum';
+import { StatusCodes } from 'http-status-codes';
+import { get as httpGet, post as httpPost } from './request.js';
+import ResponseError from './response.error.js';
+import configuration from './config.js';
+import log from './log.js';
+
+const defaults = {
+    errorThresholdPercentage: 50,
+    resetTimeout: 30000,
+    rollingCountBuckets: 10,
+    rollingCountTimeout: 60000,
+    timeout: 8000,
+    volumeThreshold: 5,
+};
+const { circuitBreaker: overrides = {} } = configuration;
+const options = {
+    ...defaults,
+    ...overrides,
+    // Non-transient responses (4xx other than 408/429) are the caller's
+    // problem, not a Bungie outage; they reject but never open the circuit.
+    errorFilter: err => err instanceof ResponseError && !err.isTransient,
+};
+// The breaker owns outage handling, so one quick retry replaces the
+// request helper's default ladder of three with long backoff.
+const retryDefaults = { baseDelay: 500, maxDelay: 1000, maxRetries: 1 };
+
+const breaker = new CircuitBreaker((fn, ...args) => fn(...args), options);
+
+breaker.on('open', () => log.warn('Bungie circuit breaker opened'));
+breaker.on('halfOpen', () => log.info('Bungie circuit breaker half-open; probing'));
+breaker.on('close', () => log.info('Bungie circuit breaker closed'));
+
+/**
+ * Fire the breaker, translating its open-circuit rejection into a 503 the
+ * error middleware understands.
+ *
+ * @param {Function} fn - Underlying request helper.
+ * @param {...*} args - Arguments forwarded to the helper.
+ * @returns {Promise<*>}
+ */
+async function fire(fn, ...args) {
+    try {
+        return await breaker.fire(fn, ...args);
+    } catch (err) {
+        if (err.code === 'EOPENBREAKER') {
+            err.message = 'Bungie API circuit breaker is open.';
+            err.statusCode = StatusCodes.SERVICE_UNAVAILABLE;
+        }
+
+        throw err;
+    }
+}
+
+/**
+ * Bound the whole logical call (attempt + backoff + retry) with a signal
+ * that actually cancels the socket; opossum's timeout only rejects.
+ *
+ * @param {object} requestOptions
+ * @returns {object}
+ */
+const withSignal = requestOptions => ({
+    signal: AbortSignal.timeout(options.timeout),
+    ...requestOptions,
+});
+
+/**
+ * GET from the Bungie API through the circuit breaker.
+ *
+ * @param {object} requestOptions - Options for {@link module:helpers/request~get}.
+ * @param {boolean} [includeHeaders=false]
+ * @param {object} [retryOptions]
+ * @returns {Promise<*>}
+ */
+async function get(requestOptions, includeHeaders = false, retryOptions) {
+    return await fire(httpGet, withSignal(requestOptions), includeHeaders, {
+        ...retryDefaults,
+        ...retryOptions,
+    });
+}
+
+/**
+ * POST to the Bungie API through the circuit breaker.
+ *
+ * @param {object} requestOptions - Options for {@link module:helpers/request~post}.
+ * @param {object} [retryOptions]
+ * @returns {Promise<*>}
+ */
+async function post(requestOptions, retryOptions) {
+    return await fire(httpPost, withSignal(requestOptions), {
+        ...retryDefaults,
+        ...retryOptions,
+    });
+}
+
+/**
+ * Snapshot of the breaker's state and rolling-window statistics.
+ *
+ * @returns {{ state: string, stats: object }}
+ */
+function getCircuitBreakerStatus() {
+    const state = breaker.opened ? 'open' : breaker.halfOpen ? 'half-open' : 'closed';
+    const { failures, rejects, successes, timeouts } = breaker.stats;
+
+    return { state, stats: { failures, rejects, successes, timeouts } };
+}
+
+export { breaker, get, getCircuitBreakerStatus, post };

--- a/helpers/bungie.request.spec.js
+++ b/helpers/bungie.request.spec.js
@@ -93,6 +93,23 @@ describe('bungie.request', () => {
             );
         });
 
+        it('should combine a caller-provided signal with the timeout signal', async () => {
+            const controller = new AbortController();
+
+            httpGet.mockResolvedValue({});
+
+            await bungie.get({ signal: controller.signal, url: 'https://example.com/api' });
+
+            const [{ signal }] = httpGet.mock.calls[0];
+
+            expect(signal).not.toBe(controller.signal);
+            expect(signal.aborted).toBe(false);
+
+            controller.abort();
+
+            expect(signal.aborted).toBe(true);
+        });
+
         it('should forward includeHeaders and caller retry overrides', async () => {
             const body = { data: { name: 'test' }, headers: {} };
 

--- a/helpers/bungie.request.spec.js
+++ b/helpers/bungie.request.spec.js
@@ -1,0 +1,242 @@
+import { StatusCodes } from 'http-status-codes';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./request.js', () => ({
+    get: vi.fn(),
+    post: vi.fn(),
+}));
+
+vi.mock('./config.js', () => ({
+    default: {},
+}));
+
+vi.mock('./log.js', () => ({
+    default: {
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+    },
+}));
+
+describe('bungie.request', () => {
+    let breaker;
+    let bungie;
+    let httpGet;
+    let httpPost;
+    let log;
+    let ResponseError;
+
+    const transientError = () =>
+        new ResponseError({
+            response: {
+                data: {},
+                status: StatusCodes.SERVICE_UNAVAILABLE,
+                statusText: 'Service Unavailable',
+            },
+        });
+    const nonTransientError = () =>
+        new ResponseError({
+            response: {
+                data: {},
+                status: StatusCodes.NOT_FOUND,
+                statusText: 'Not Found',
+            },
+        });
+
+    /**
+     * Defaults from bungie.request.js: volumeThreshold 5, timeout 8000,
+     * resetTimeout 30000. Five consecutive transient failures open the circuit.
+     */
+    async function openBreaker() {
+        httpGet.mockRejectedValue(transientError());
+
+        for (let i = 0; i < 5; i++) {
+            await expect(bungie.get({ url: 'https://example.com/api' })).rejects.toMatchObject({
+                name: 'RequestError',
+            });
+        }
+    }
+
+    beforeEach(async () => {
+        vi.useFakeTimers();
+        vi.resetModules();
+
+        bungie = await import('./bungie.request.js');
+        breaker = bungie.breaker;
+        ({ get: httpGet, post: httpPost } = await import('./request.js'));
+        ({ default: log } = await import('./log.js'));
+        ({ default: ResponseError } = await import('./response.error.js'));
+    });
+
+    afterEach(() => {
+        breaker.shutdown();
+        vi.useRealTimers();
+        vi.clearAllMocks();
+    });
+
+    describe('pass-through', () => {
+        it('should delegate get and return its data', async () => {
+            const body = { name: 'test' };
+
+            httpGet.mockResolvedValue(body);
+
+            const result = await bungie.get({ url: 'https://example.com/api' });
+
+            expect(result).toEqual(body);
+            expect(httpGet).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    signal: expect.any(AbortSignal),
+                    url: 'https://example.com/api',
+                }),
+                false,
+                expect.objectContaining({ baseDelay: 500, maxDelay: 1000, maxRetries: 1 }),
+            );
+        });
+
+        it('should forward includeHeaders and caller retry overrides', async () => {
+            const body = { data: { name: 'test' }, headers: {} };
+
+            httpGet.mockResolvedValue(body);
+
+            const result = await bungie.get({ url: 'https://example.com/api' }, true, {
+                maxRetries: 3,
+            });
+
+            expect(result).toEqual(body);
+            expect(httpGet).toHaveBeenCalledWith(
+                expect.any(Object),
+                true,
+                expect.objectContaining({ baseDelay: 500, maxRetries: 3 }),
+            );
+        });
+
+        it('should delegate post and return its data', async () => {
+            const body = { id: 1 };
+
+            httpPost.mockResolvedValue(body);
+
+            const result = await bungie.post({ url: 'https://example.com/api', data: {} });
+
+            expect(result).toEqual(body);
+            expect(httpPost).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    signal: expect.any(AbortSignal),
+                    url: 'https://example.com/api',
+                }),
+                expect.objectContaining({ baseDelay: 500, maxDelay: 1000, maxRetries: 1 }),
+            );
+        });
+    });
+
+    describe('open circuit', () => {
+        it('should open after the volume threshold of transient failures', async () => {
+            await openBreaker();
+
+            expect(log.warn).toHaveBeenCalledWith('Bungie circuit breaker opened');
+            expect(breaker.opened).toBe(true);
+        });
+
+        it('should fail fast with a 503 without calling the underlying helper', async () => {
+            await openBreaker();
+
+            expect(httpGet).toHaveBeenCalledTimes(5);
+
+            await expect(bungie.get({ url: 'https://example.com/api' })).rejects.toMatchObject({
+                code: 'EOPENBREAKER',
+                message: 'Bungie API circuit breaker is open.',
+                statusCode: StatusCodes.SERVICE_UNAVAILABLE,
+            });
+            expect(httpGet).toHaveBeenCalledTimes(5);
+        });
+    });
+
+    describe('errorFilter', () => {
+        it('should not open the circuit on non-transient errors', async () => {
+            httpGet.mockRejectedValue(nonTransientError());
+
+            for (let i = 0; i < 10; i++) {
+                await expect(bungie.get({ url: 'https://example.com/api' })).rejects.toMatchObject({
+                    status: StatusCodes.NOT_FOUND,
+                });
+            }
+
+            expect(breaker.opened).toBe(false);
+
+            httpGet.mockResolvedValue({ ok: true });
+
+            await expect(bungie.get({ url: 'https://example.com/api' })).resolves.toEqual({
+                ok: true,
+            });
+            expect(httpGet).toHaveBeenCalledTimes(11);
+        });
+    });
+
+    describe('recovery', () => {
+        it('should close again after a successful half-open probe', async () => {
+            await openBreaker();
+
+            await vi.advanceTimersByTimeAsync(30000);
+
+            expect(log.info).toHaveBeenCalledWith('Bungie circuit breaker half-open; probing');
+
+            httpGet.mockResolvedValue({ ok: true });
+
+            await expect(bungie.get({ url: 'https://example.com/api' })).resolves.toEqual({
+                ok: true,
+            });
+            expect(log.info).toHaveBeenCalledWith('Bungie circuit breaker closed');
+            expect(breaker.closed).toBe(true);
+        });
+
+        it('should reopen when the half-open probe fails', async () => {
+            await openBreaker();
+
+            await vi.advanceTimersByTimeAsync(30000);
+
+            await expect(bungie.get({ url: 'https://example.com/api' })).rejects.toMatchObject({
+                name: 'RequestError',
+            });
+            expect(breaker.opened).toBe(true);
+
+            const calls = httpGet.mock.calls.length;
+
+            await expect(bungie.get({ url: 'https://example.com/api' })).rejects.toMatchObject({
+                code: 'EOPENBREAKER',
+            });
+            expect(httpGet).toHaveBeenCalledTimes(calls);
+        });
+    });
+
+    describe('timeout', () => {
+        it('should count a hung request as a timeout failure', async () => {
+            httpGet.mockImplementation(() => new Promise(() => {}));
+
+            const promise = bungie.get({ url: 'https://example.com/api' });
+            const assertion = expect(promise).rejects.toMatchObject({ code: 'ETIMEDOUT' });
+
+            await vi.advanceTimersByTimeAsync(8000);
+            await assertion;
+
+            expect(bungie.getCircuitBreakerStatus().stats.timeouts).toBe(1);
+        });
+    });
+
+    describe('getCircuitBreakerStatus', () => {
+        it('should report a closed breaker with rolling statistics', async () => {
+            httpGet.mockResolvedValue({ ok: true });
+
+            await bungie.get({ url: 'https://example.com/api' });
+
+            const status = bungie.getCircuitBreakerStatus();
+
+            expect(status.state).toBe('closed');
+            expect(status.stats).toMatchObject({ failures: 0, successes: 1 });
+        });
+
+        it('should report an open breaker', async () => {
+            await openBreaker();
+
+            expect(bungie.getCircuitBreakerStatus().state).toBe('open');
+        });
+    });
+});

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
         "ioredis": "^5.11.1",
         "lru-cache": "^11.5.2",
         "nodemailer": "^9.0.3",
+        "opossum": "^10.0.0",
         "p-limit": "^7.3.0",
         "p-throttle": "^8.1.0",
         "pino": "^10.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       nodemailer:
         specifier: ^9.0.3
         version: 9.0.3
+      opossum:
+        specifier: ^10.0.0
+        version: 10.0.0
       p-limit:
         specifier: ^7.3.0
         version: 7.3.0
@@ -2490,6 +2493,10 @@ packages:
 
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
+
+  opossum@10.0.0:
+    resolution: {integrity: sha512-sghtqL8Usj+et06Zui0nyn0R6FFsl7cyuoU+d7MctYU0nbS7Htzjleh+tWohFqk1Rp1srrFwbFa8Vxd0O64w6A==}
+    engines: {node: ^26 || ^24 || ^22}
 
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
@@ -5982,6 +5989,8 @@ snapshots:
       wsl-utils: 0.1.0
 
   openapi-types@12.1.3: {}
+
+  opossum@10.0.0: {}
 
   outvariant@1.4.3: {}
 


### PR DESCRIPTION
## Summary
Wraps all Bungie API traffic in a single shared circuit breaker (`helpers/bungie.request.js`) so maintenance-window outages no longer cascade into slow, retry-bound requests across the service.

Solves issue #456.

- One breaker pools failure statistics for all Bungie endpoints; the bitly, director, and Twilio status clients keep using the raw request helper.
- Injects `AbortSignal.timeout` per logical call, closing the gap where outbound fetches had no timeout at all, and trims the inner retry ladder to one quick retry now that the breaker owns outage handling.
- Filters non-transient responses (4xx other than 408/429) out of the failure count via `ResponseError.isTransient`; they still reject the caller.
- Translates the open-breaker rejection into a 503 the existing error middleware already understands, and reports breaker state and rolling stats on the health endpoint without counting an open circuit as a service failure.
- Cache-aside flows are unchanged: cache hits keep serving while the circuit is open; misses fail fast instead of hanging.

## Known limitation
Bungie occasionally signals maintenance as HTTP 200 with body ErrorCode 5, which surfaces as `DestinyError` above the breaker and does not trip it.

## Test plan
- [x] Full suite passes (477 tests, 46 files) including new specs for `bungie.request`, health controller, and health routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)