### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @chrispaskvan


### PR DESCRIPTION
## Summary
- Add a CODEOWNERS file with @chrispaskvan as the default owner for all repository files.

## Testing
- Not run (CODEOWNERS-only change).

Note: the local pre-push hook was stopped after the test command produced no output for several minutes.