### PR TITLE
fix(security): fetch CSRF token before sign-out request

### DIFF
--- a/signIn.html
+++ b/signIn.html
@@ -35,7 +35,7 @@
                         .then(({ csrfToken }) => jQuery.ajax({
                             contentType: 'application/json; charset=utf-8',
                             type: 'POST',
-                            url: '/users/signout',
+                            url: '/users/signOut',
                             headers: { 'x-csrf-token': csrfToken }
                         }))
                         .always(() => {

--- a/signIn.html
+++ b/signIn.html
@@ -29,10 +29,15 @@
                 this.welcomeMessage = ko.pureComputed(() => `Welcome ${user.displayName}`);
                 this.signOut = () => {
                     jQuery.ajax({
-                        contentType: 'application/json; charset=utf-8',
-                        type: 'POST',
-                        url: '/users/signout'
+                        type: 'GET',
+                        url: '/users/current/csrfToken'
                     })
+                        .then(({ csrfToken }) => jQuery.ajax({
+                            contentType: 'application/json; charset=utf-8',
+                            type: 'POST',
+                            url: '/users/signout',
+                            headers: { 'x-csrf-token': csrfToken }
+                        }))
                         .always(() => {
                             window.location = '/';
                         });


### PR DESCRIPTION
## Summary
- `POST /users/signOut` has required an `x-csrf-token` header since #648 added CSRF protection to session-authenticated mutating routes, but `signIn.html`'s `signOut` handler never fetched or sent one.
- As a result, sign-out requests from the sign-in page have been failing with **403 Forbidden** since #648 merged (2026-07-26), and the server-side session was never destroyed.
- Fix: fetch a token from `GET /users/current/csrfToken` (which the signed-in session already authenticates for) before the sign-out POST, and echo it back via the `x-csrf-token` header. `.always()` still redirects home regardless of outcome, preserving prior UX.

## Test plan
- [x] `pnpm lint` (biome) — clean
- [x] `pnpm test` — 522 passed, 1 skipped (pre-push hook)
- [ ] Manual smoke test: sign in, click "Sign Out", confirm 204 from `/users/signout` in devtools network tab and session cookie is cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)